### PR TITLE
Add yara-backend crate: pure-Rust YARA facade for MalChela tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.0",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +91,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -173,6 +199,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii_tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +337,38 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bindgen"
@@ -276,7 +385,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
 ]
@@ -298,6 +407,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -309,12 +421,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -328,6 +463,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
@@ -366,6 +504,12 @@ dependencies = [
  "serde",
  "serde_yaml",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -422,6 +566,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -492,6 +663,15 @@ dependencies = [
  "thiserror 2.0.18",
  "which 8.0.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -583,6 +763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +810,190 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.33.0",
+ "hashbrown 0.16.1",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
+
+[[package]]
+name = "cranelift-control"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
+
+[[package]]
+name = "cranelift-native"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.130.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -658,6 +1028,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,12 +1071,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d87f75bbe32ee10609201e09e818537df81c3acb436be2b78f47cc85d139475"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dataview"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daba87f72c730b508641c9fb6411fc9bba73939eed2cab611c399500511880d0"
 dependencies = [
  "derive_pod",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -732,7 +1186,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -795,10 +1251,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -905,6 +1424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -984,6 +1519,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1027,6 +1563,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1152,6 +1694,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1161,8 +1704,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1201,10 +1746,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.11.1",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "goblin"
@@ -1215,6 +1807,17 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1268,6 +1871,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1284,6 +1893,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1346,6 +1957,33 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1641,6 +2279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +2303,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1736,6 +2396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "intaglio"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e062125b1cb1523e2032c12f3a5bac6947ccd1f8c0a8aae96f63609fe0e34ee"
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +2410,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1778,6 +2453,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1845,12 +2529,21 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "leb128fmt"
@@ -1901,6 +2594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +2607,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1937,6 +2642,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2004,6 +2752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "md2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4f0f3ed25ff4f8d8d102288d92f900efc202661c884cf67dfe4f0d07c43d1f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2771,24 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -2230,6 +3005,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +3047,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2280,6 +3083,27 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -2292,6 +3116,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -2342,6 +3172,30 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "papergrid"
@@ -2437,6 +3291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7cf3f8ecebb0f4895f4892a8be0a0dc81b498f9d56735cb769dc31bf00815b"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +3350,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +3412,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,6 +3465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -2615,6 +3539,15 @@ dependencies = [
  "lazy_static",
  "term",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2698,6 +3631,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "psl"
+version = "2.1.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "pulley-interpreter"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,11 +3771,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2763,8 +3792,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2782,6 +3821,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2808,7 +3850,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -2820,7 +3862,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -2880,6 +3922,20 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.0",
+ "log",
+ "rustc-hash 2.1.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -2994,6 +4050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,6 +4080,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rqrr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,10 +4112,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustix"
@@ -3039,7 +4183,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3142,6 +4286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,6 +4364,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3306,10 +4465,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -3319,6 +4498,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3337,6 +4522,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3356,6 +4544,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3402,7 +4606,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -3415,6 +4619,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3596,6 +4812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,7 +4832,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3620,12 +4848,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3649,6 +4886,12 @@ checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
  "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -3743,6 +4986,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3904,6 +5157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,6 +5203,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -4003,6 +5268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vte"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,6 +5290,34 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "walrus"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e151599d689dac80e85c66a7cfa6ffd1b2ab79220517f9161040a87a5041aee3"
+dependencies = [
+ "anyhow",
+ "gimli 0.32.3",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9b0525d7ea6e5f906aca581a172e5c91b4c595290dfa8ad4a2bc9ffef33b44"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4116,7 +5415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -4127,8 +5436,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4154,6 +5463,193 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasmtime"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.245.1",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
+dependencies = [
+ "anyhow",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.33.0",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+ "wasmprinter",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.33.0",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.245.1",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "43.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4184,13 +5680,25 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -4547,9 +6055,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -4568,7 +6076,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4576,6 +6084,32 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "xmzhash"
@@ -4610,12 +6144,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "yara-backend"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "log",
+ "parking_lot",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "walkdir",
+ "yara-x",
+]
+
+[[package]]
 name = "yara-sys"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbeb5b2ed726cb3786945423539732a681ce2eb9911ee5e7548fad7ca96b0731"
 dependencies = [
  "bindgen",
+]
+
+[[package]]
+name = "yara-x"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6331ceb153230853dd2d0f2dc1e05e21ffa8b9b683bf7fd5cbd8c469bd28bdbc"
+dependencies = [
+ "annotate-snippets",
+ "anyhow",
+ "base64 0.22.1",
+ "bincode",
+ "bitflags 2.11.1",
+ "bitvec",
+ "bstr",
+ "const-oid",
+ "crc32fast",
+ "daachorse",
+ "der-parser",
+ "digest",
+ "dsa",
+ "ecdsa",
+ "getrandom 0.2.17",
+ "globwalk",
+ "hex",
+ "indexmap",
+ "intaglio",
+ "inventory",
+ "ipnet",
+ "itertools 0.14.0",
+ "js-sys",
+ "md-5",
+ "md2",
+ "memchr",
+ "memmap2",
+ "nom 8.0.0",
+ "num-derive",
+ "num-traits",
+ "p256",
+ "p384",
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-parse",
+ "psl",
+ "regex",
+ "regex-automata",
+ "regex-syntax",
+ "roxmltree",
+ "rsa",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "simd-adler32",
+ "simd_cesu8",
+ "smallvec",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "uuid",
+ "walrus",
+ "wasm-bindgen",
+ "wasmtime",
+ "x509-parser",
+ "yara-x-macros",
+ "yara-x-parser",
+ "yara-x-proto",
+ "zip",
+]
+
+[[package]]
+name = "yara-x-macros"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb91fd95a7284f36513ece2ad09c7226af4093c8e0f6052c51943bbf877768ad"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "yara-x-parser"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9505add0a82252c8016730a92471ec1b33a26943cb300fa22efaca4165eee02b"
+dependencies = [
+ "ascii_tree",
+ "bitflags 2.11.1",
+ "bstr",
+ "indexmap",
+ "itertools 0.14.0",
+ "logos",
+ "num-traits",
+ "rowan",
+ "rustc-hash 2.1.2",
+ "serde",
+]
+
+[[package]]
+name = "yara-x-proto"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60a957ada6d583373dbc0d644f10735383ab92f666ae1cc91f7b982d4b6a153"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -4722,10 +6378,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "about", "combine_yara", "extract_samples", "fileanalyzer", "hashit", "mstrings", "malchela", "mzcount", "strings_to_yara", "cached", "common_config", "mismatchminer", "nsrlquery", "config", "common_ui", "hashcheck", "mzhash", "xmzhash", "fileminer", "MITRE_lookup", "tiquery", "plist_analyzer", "macho_info", "codesign_check"]
+members = [ "about", "combine_yara", "extract_samples", "fileanalyzer", "hashit", "mstrings", "malchela", "mzcount", "strings_to_yara", "cached", "common_config", "mismatchminer", "nsrlquery", "config", "common_ui", "hashcheck", "mzhash", "xmzhash", "fileminer", "MITRE_lookup", "tiquery", "plist_analyzer", "macho_info", "codesign_check", "yara-backend"]
 
 [patch.crates-io]
 serde_yml = { path = "vendor/serde_yml" }

--- a/yara-backend/BASELINE.md
+++ b/yara-backend/BASELINE.md
@@ -1,0 +1,78 @@
+# Performance baseline
+
+Captured numbers from `cargo bench -p yara-backend`, used as the
+reference point for future regression checks. Re-run on the same
+hardware after any change that touches the compile or scan path.
+
+Re-running:
+
+```
+cargo bench -p yara-backend
+```
+
+Criterion writes per bench reports to `target/criterion/`.
+
+## Capture environment (2026-05-16)
+
+* OS: WSL2 (Linux 6.6.87.2 microsoft standard)
+* Rust: `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`, `rustc 1.95.0 (59807616e 2026-04-14)`
+* Build profile: `bench` (release with debug = false)
+* yara-x version: 1.16.0
+
+## Compile path
+
+Measured by `benches/compile.rs`. Compiles N inline rules through
+`YaraBackend::from_inline_sources` and discards the result.
+
+| Rules | Median |
+|------:|-------:|
+| 1     | 4.97 ms |
+| 10    | 5.56 ms |
+| 100   | 9.67 ms |
+
+Rule count scales sub-linearly past the fixed yara-x compiler startup
+cost. The first compile dominates the budget.
+
+## Scan path (in memory)
+
+Measured by `benches/scan_mem.rs`. Calls `YaraBackend::scan_bytes`
+against a deterministic LCG generated buffer with a 10 rule corpus
+that never matches.
+
+| Size  | Median   | Throughput |
+|------:|---------:|-----------:|
+| 1 KiB | 376 us   | 2.60 MiB/s |
+| 1 MiB | 486 us   | 2.01 GiB/s |
+| 16 MiB | 2.70 ms | 5.78 GiB/s |
+
+The 1 KiB number reflects scanner setup overhead (a fresh
+`yara_x::Scanner` is allocated per call); throughput rises sharply
+once the scan kernel can amortise setup against larger inputs.
+
+## Scan path (on disk)
+
+Measured by `benches/scan_file.rs`. Same corpus, same buffer sizes,
+but read from a temp file via `YaraBackend::scan_file`.
+
+| Size  | Median   | Throughput |
+|------:|---------:|-----------:|
+| 1 KiB | 404 us   | 2.42 MiB/s |
+| 1 MiB | 575 us   | 1.70 GiB/s |
+| 16 MiB | 5.12 ms | 3.05 GiB/s |
+
+yara-x mmaps the file by default. The 16 MiB on disk number is
+slower than the 16 MiB in memory number because mmap setup and page
+fault costs are real at that size; for our typical sample sizes
+(a few MB) the gap is negligible.
+
+## Regression rules
+
+* Any change pushing compile time above 15 ms for 100 inline rules is
+  worth a closer look.
+* Any change dropping scan throughput below half of these baselines
+  at any size is a regression worth blocking.
+* Any new bench that produces a number more than 5 percent worse than
+  these should justify the cost in the PR description.
+
+These rules are guidance, not gating. Run the suite, eyeball the
+delta, write a one liner in the PR if anything moved.

--- a/yara-backend/CHANGELOG.md
+++ b/yara-backend/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this crate will be documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and the crate uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 — Initial release
+
+First public version of the wrapper. Internal to the MalChela workspace
+for now; not published to crates.io.
+
+### Added
+
+* `YaraBackend` facade with two constructors. `load_from_dir` walks a
+  directory for `.yar` / `.yara` files; `from_inline_sources` compiles
+  `(namespace, source)` pairs already in memory.
+* `scan_file` and `scan_bytes` paths, both running through a fresh
+  short lived yara-x `Scanner` so multi thread workers stay lock free.
+* Built in hot reload: every scan checks the rules directory and
+  recompiles if anything changed. One bad rule during a reload becomes
+  a warning, not a hard fail.
+* `Match`, `MatchedString`, `ScanReport` result types. `meta` is a
+  `BTreeMap` and `matches` is sorted by `(rule name, namespace, first
+  offset)` so two runs of the same scan produce identical reports.
+* `Error` enum with `#[non_exhaustive]`, covering load errors, compile
+  errors, unsupported modules, timeouts, lock contention, and IO.
+* Pre compile audit that refuses rules importing modules yara-x does
+  not implement (`magic` today).
+* Companion shell script `tools/audit_yara_rules.sh` for CI hooks.
+* Three criterion benchmarks: compile, scan_bytes, scan_file.
+
+### Tested
+
+117 tests in the suite:
+
+* 83 unit tests across `error`, `match_types`, `audit`, `compile`,
+  `cache`, `scan`, and `backend` modules.
+* 6 audit evasion tests: extra whitespace, tabs, escape sequences,
+  block and line comments, capitalised module names.
+* 1 chaos test: 8 worker threads, 250 random ops each (writes,
+  deletes, scans, reloads), no panics or deadlocks.
+* 3 concurrency tests covering parallel scans, parallel reloads, and
+  mixed reader / writer access from `Arc<YaraBackend>`.
+* 5 determinism tests: same input produces identical reports across
+  runs; metadata key order is alphabetic; matches are sorted.
+* 8 inline rule regression tests, one per MalChela consumer that
+  ships an inline rule string today.
+* 9 file based load tests against committed fixtures in
+  `tests/fixtures/rules/`.
+* 2 README example tests: every code snippet in `README.md` is
+  transcribed into a real test so doc drift gets caught.

--- a/yara-backend/Cargo.toml
+++ b/yara-backend/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "yara-backend"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Rule loading and scanning facade backed by yara-x. Used by MalChela's analysis tools."
+repository = "https://github.com/dwmetz/MalChela"
+
+[dependencies]
+yara-x = "1.16"
+thiserror = "1"
+parking_lot = "0.12"
+walkdir = "2"
+log = "0.4"
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = "1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "compile"
+harness = false
+
+[[bench]]
+name = "scan_mem"
+harness = false
+
+[[bench]]
+name = "scan_file"
+harness = false

--- a/yara-backend/README.md
+++ b/yara-backend/README.md
@@ -1,0 +1,143 @@
+# yara-backend
+
+A small wrapper crate that gives MalChela's analysis tools one place to
+load YARA rules and scan files or buffers. Under the hood it uses
+[`yara-x`](https://crates.io/crates/yara-x), the pure Rust YARA engine
+maintained by VirusTotal.
+
+## Why this exists
+
+MalChela tools used to depend on the `yara` crate, which needs libyara
+as a C library. That C dep is the main blocker for a native Windows
+build and adds work to every `cargo build` from a clean target.
+
+This crate owns the YARA surface so:
+
+* Each MalChela tool calls one Rust API instead of importing yara directly.
+* The choice of engine (`yara-x` today) can change later without touching
+  every caller.
+* Cross platform builds work without a system libyara install.
+
+## Quick start
+
+Load rules from a directory:
+
+```rust
+use std::time::Duration;
+use yara_backend::YaraBackend;
+
+let backend = YaraBackend::load_from_dir("./yara_rules")?;
+let report = backend.scan_file("sample.bin", Duration::from_secs(5))?;
+for name in report.rule_names_sorted() {
+    println!("matched: {name}");
+}
+```
+
+Or compile inline rules (handy for small built in rules a tool ships
+alongside its source):
+
+```rust
+use std::time::Duration;
+use yara_backend::YaraBackend;
+
+const MZ_RULE: &str = r#"
+    rule mz_header {
+        strings: $mz = { 4D 5A }
+        condition: $mz at 0
+    }
+"#;
+
+let backend = YaraBackend::from_inline_sources(&[("default", MZ_RULE)])?;
+let mut sample = vec![0u8; 64];
+sample[0] = 0x4D;
+sample[1] = 0x5A;
+let report = backend.scan_bytes(&sample, Duration::ZERO)?;
+assert_eq!(report.rule_names_sorted(), vec!["mz_header"]);
+```
+
+`Duration::ZERO` disables the per scan timeout; pass a non zero
+Duration to enforce one.
+
+## API at a glance
+
+| Type | What it is |
+|------|------------|
+| `YaraBackend` | Top level facade. Cheap to clone (Arc backed), safe to share across threads. |
+| `ScanReport` | Result of a scan: matches, elapsed time, rules evaluated, compile warnings. |
+| `Match` | One matching rule: name, namespace, tags, matched strings, metadata. |
+| `MatchedString` | One byte match: pattern id, offset, raw bytes. |
+| `Error` | Every failure mode the wrapper can hit. Has `#[non_exhaustive]` so adding new variants later is not a breaking change. |
+
+Helper methods worth knowing:
+
+* `YaraBackend::reload_if_changed()` re-walks the rules directory and
+  recompiles if anything changed. Called automatically before every
+  scan, so the "drop a `.yar`, instantly available" workflow still
+  works.
+* `ScanReport::rule_names_sorted()` returns alphabetical, deduplicated
+  rule names. This is what the JSON layer reaches for so output stays
+  stable across runs.
+
+## Hot reload
+
+If you load from a directory, `scan_file` and `scan_bytes` check the
+directory for changes before each scan. A file's `(size, mtime)` makes
+the signature; if the signature differs from the cached one, the
+backend recompiles. The data on disk is the source of truth.
+
+One bad rule during a reload becomes a warning rather than aborting
+the reload. The other rules still compile and scans keep working.
+The compile warnings surface on `ScanReport::compile_warnings` so
+callers can show them to the operator.
+
+## Thread safety
+
+`YaraBackend` is `Send + Sync`. Wrap it in an `Arc` and hand it to as
+many worker threads as you like. Each scan allocates its own short
+lived yara-x `Scanner`, so the read path is lock free.
+
+## Trust model and resource caps
+
+The crate is designed for the rule sources MalChela's own tools ship
+(inline string constants baked into the binary) and the rule files an
+operator drops into `yara_rules/` on a machine they control. Both are
+trusted inputs at this layer.
+
+To keep a runaway or adversarial caller from exhausting memory, the
+wrapper enforces hard upper bounds checked at the public API boundary:
+
+| Input | Cap | Error variant when exceeded |
+|-------|-----|----------------------------|
+| Rule source string (inline) | 16 MiB per source | `Error::SourceTooLarge` |
+| Rule file on disk (`.yar` / `.yara`) | 16 MiB per file | `Error::SourceTooLarge` |
+| Scan buffer (`scan_bytes`) | 256 MiB per call | `Error::ScanInputTooLarge` |
+| Scan file (`scan_file`) | 256 MiB per call | `Error::ScanInputTooLarge` |
+
+These limits are generous compared to real YARA corpora (kilobytes to
+a few megabytes) and real malware samples (typically under 100 MB).
+The caps are constants in `src/compile.rs` and `src/scan.rs`. If a
+future caller needs higher limits we will make them configurable
+through a builder pattern; for now they are hard coded.
+
+The per scan `yara_x::Scanner` allocation is short lived and not
+itself capped. High fan out workloads (many parallel calls from
+`par_iter` style worker pools) are supported by design but the
+allocation cost is real and is caller visible.
+
+## Engine compatibility
+
+yara-x implements most of YARA but not every libyara module. The
+ones currently missing are caught by a pre compile audit:
+
+* `import "magic"` is refused with `Error::UnsupportedModule`. Rules
+  using `magic.type()` and friends will not compile.
+
+A companion shell script,
+[`tools/audit_yara_rules.sh`](tools/audit_yara_rules.sh), runs the
+same check from CI so unsupported rules are caught before cargo even
+starts compiling.
+
+## License
+
+MIT (matches the parent MalChela crate). yara-x itself is BSD-3-Clause
+and is bundled as a regular crate dependency.

--- a/yara-backend/benches/compile.rs
+++ b/yara-backend/benches/compile.rs
@@ -1,0 +1,38 @@
+//! Compile path benchmarks.
+//!
+//! Measures the time taken to compile 1, 10, and 100 inline rules through
+//! the public `from_inline_sources` path. The numbers feed into the
+//! crate's BASELINE.md so future PRs can detect performance regressions.
+//!
+//! Run with: `cargo bench -p yara-backend --bench compile`
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use yara_backend::YaraBackend;
+
+fn make_rules_source(n: usize) -> String {
+    let mut s = String::new();
+    for i in 0..n {
+        s.push_str(&format!(
+            "rule r_{i} {{ strings: $s_{i} = \"marker_{i}\" condition: $s_{i} }}\n"
+        ));
+    }
+    s
+}
+
+fn bench_compile(c: &mut Criterion) {
+    for n in [1usize, 10, 100] {
+        let src = make_rules_source(n);
+        c.bench_function(&format!("compile_{n}_inline_rules"), |b| {
+            b.iter(|| {
+                let backend =
+                    YaraBackend::from_inline_sources(&[("default", black_box(src.as_str()))])
+                        .expect("compile");
+                black_box(backend.rule_count());
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bench_compile);
+criterion_main!(benches);

--- a/yara-backend/benches/scan_file.rs
+++ b/yara-backend/benches/scan_file.rs
@@ -1,0 +1,63 @@
+//! On disk scan benchmarks.
+//!
+//! Mirrors scan_mem.rs but reads the buffer from a temp file via
+//! `scan_file`, exercising the IO path yara-x uses (mmap by default).
+//!
+//! Run with: `cargo bench -p yara-backend --bench scan_file`
+
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use tempfile::TempDir;
+
+use yara_backend::YaraBackend;
+
+fn ten_rules() -> String {
+    let mut s = String::new();
+    for i in 0..10 {
+        s.push_str(&format!(
+            "rule r_{i} {{ strings: $a = \"missing_marker_{i}\" condition: $a }}\n"
+        ));
+    }
+    s
+}
+
+fn lcg_buffer(size: usize) -> Vec<u8> {
+    let mut state: u64 = 0xdead_beef_cafe_babe;
+    (0..size)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 33) as u8
+        })
+        .collect()
+}
+
+fn bench_scan_file(c: &mut Criterion) {
+    let backend = YaraBackend::from_inline_sources(&[("default", ten_rules().as_str())]).unwrap();
+    let td = TempDir::new().unwrap();
+
+    let mut group = c.benchmark_group("scan_file");
+    for (label, size) in [
+        ("1KiB", 1024usize),
+        ("1MiB", 1024 * 1024),
+        ("16MiB", 16 * 1024 * 1024),
+    ] {
+        let path = td.path().join(format!("sample_{label}.bin"));
+        std::fs::write(&path, lcg_buffer(size)).unwrap();
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let r = backend
+                    .scan_file(black_box(&path), Duration::ZERO)
+                    .expect("scan");
+                black_box(r.matches.len());
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_file);
+criterion_main!(benches);

--- a/yara-backend/benches/scan_mem.rs
+++ b/yara-backend/benches/scan_mem.rs
@@ -1,0 +1,60 @@
+//! In memory scan benchmarks.
+//!
+//! Measures `scan_bytes` throughput at 1 KiB, 1 MiB, and 16 MiB buffer
+//! sizes against a 10 rule corpus. The numbers feed BASELINE.md.
+//!
+//! Run with: `cargo bench -p yara-backend --bench scan_mem`
+
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+use yara_backend::YaraBackend;
+
+fn ten_rules() -> String {
+    let mut s = String::new();
+    for i in 0..10 {
+        s.push_str(&format!(
+            "rule r_{i} {{ strings: $a = \"missing_marker_{i}\" condition: $a }}\n"
+        ));
+    }
+    s
+}
+
+fn lcg_buffer(size: usize) -> Vec<u8> {
+    let mut state: u64 = 0xdead_beef_cafe_babe;
+    (0..size)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 33) as u8
+        })
+        .collect()
+}
+
+fn bench_scan_mem(c: &mut Criterion) {
+    let backend = YaraBackend::from_inline_sources(&[("default", ten_rules().as_str())]).unwrap();
+
+    let mut group = c.benchmark_group("scan_bytes");
+    for (label, size) in [
+        ("1KiB", 1024usize),
+        ("1MiB", 1024 * 1024),
+        ("16MiB", 16 * 1024 * 1024),
+    ] {
+        let buf = lcg_buffer(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let r = backend
+                    .scan_bytes(black_box(&buf), Duration::ZERO)
+                    .expect("scan");
+                black_box(r.matches.len());
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_mem);
+criterion_main!(benches);

--- a/yara-backend/src/audit.rs
+++ b/yara-backend/src/audit.rs
@@ -1,0 +1,418 @@
+//! Pre-compile audit for rule sources.
+//!
+//! yara-x does not implement every libyara import module. Rules that use
+//! `import "magic"` (and a small handful of similar gaps) will refuse to
+//! compile under yara-x with a low level error. We do a cheap source level
+//! audit first so callers see a clear, named error instead of the engine's
+//! diagnostic, and so the same finding can be surfaced by the companion
+//! `tools/audit_yara_rules.sh` script during a CI pre-build hook.
+//!
+//! The audit walks the source as a single byte stream rather than line by
+//! line. yara-x's parser is whitespace insensitive between tokens, so
+//! `import "magic"` and `import\n"magic"` (or with a block comment in the
+//! middle) parse the same way. The audit therefore tokenises lightly:
+//!
+//! * `/* ... */` block comments are stripped first so a commented-out
+//!   import is never flagged.
+//! * `//` line comments are skipped during the walk.
+//! * String literals inside rule bodies are skipped so a rule whose
+//!   condition string happens to contain the substring `import` cannot
+//!   produce a false positive.
+//! * `import` is matched as a whole word (no false hits on
+//!   `important_var` or `$import_thing`).
+//! * Any amount of whitespace, including newlines, may sit between the
+//!   `import` keyword and the quoted module name.
+//! * String escapes inside the quoted module name (`\xHH`, `\n`, `\t`,
+//!   `\\`, `\"`, `\'`) are decoded before the comparison so that
+//!   `import "ma\x67ic"` is recognised as `import "magic"`.
+//!
+//! Anything more involved (preprocessor tricks, exotic Unicode, etc.) is
+//! out of scope; yara-x will still refuse such rules at compile time and
+//! the wrapper surfaces the engine's error.
+
+use std::path::Path;
+
+use crate::error::{Error, Result};
+
+/// Modules that yara-x does not currently implement. Adding a module to this
+/// list means rule files mentioning it will be rejected at load time with a
+/// clear error rather than a low level engine diagnostic.
+pub(crate) const FORBIDDEN_IMPORTS: &[&str] = &["magic"];
+
+const IMPORT_KEYWORD: &[u8] = b"import";
+
+pub(crate) fn audit_rule_source(path: &Path, src: &str) -> Result<()> {
+    let stripped = strip_block_comments(src);
+    let bytes = stripped.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        // Line comment runs to end of line.
+        if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // A string literal inside a rule body could otherwise contain the
+        // substring `import`; skip it as one token so we don't false-flag.
+        if b == b'"' || b == b'\'' {
+            i = skip_string_literal(bytes, i, b);
+            continue;
+        }
+
+        // Whole-word match for `import`.
+        if matches_keyword(bytes, i, IMPORT_KEYWORD) {
+            let after_keyword = i + IMPORT_KEYWORD.len();
+            let j = skip_ws_and_line_comments(bytes, after_keyword);
+            if j < bytes.len() && (bytes[j] == b'"' || bytes[j] == b'\'') {
+                let quote = bytes[j];
+                if let Some((module, end)) = read_quoted_module(bytes, j + 1, quote) {
+                    for forbidden in FORBIDDEN_IMPORTS {
+                        if module == *forbidden {
+                            return Err(Error::UnsupportedModule {
+                                path: path.to_path_buf(),
+                                module: (*forbidden).to_string(),
+                            });
+                        }
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+            i = after_keyword;
+            continue;
+        }
+
+        i += 1;
+    }
+    Ok(())
+}
+
+/// Advance past ASCII whitespace and `//` line comments. Block comments
+/// have already been stripped from the source before the walker starts.
+fn skip_ws_and_line_comments(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        if bytes[i] == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    i
+}
+
+fn matches_keyword(bytes: &[u8], start: usize, kw: &[u8]) -> bool {
+    let end = start + kw.len();
+    if end > bytes.len() || &bytes[start..end] != kw {
+        return false;
+    }
+    let before_ok = start == 0 || !is_ident_byte(bytes[start - 1]);
+    let after_ok = end == bytes.len() || !is_ident_byte(bytes[end]);
+    before_ok && after_ok
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn skip_string_literal(bytes: &[u8], start: usize, quote: u8) -> usize {
+    debug_assert_eq!(bytes[start], quote);
+    let mut i = start + 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if bytes[i] == quote {
+            return i + 1;
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Read a quoted module string starting just after the opening quote.
+/// Returns the decoded module name and the byte index immediately after the
+/// closing quote.
+fn read_quoted_module(bytes: &[u8], start: usize, quote: u8) -> Option<(String, usize)> {
+    let mut decoded = String::new();
+    let mut i = start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == quote {
+            return Some((decoded, i + 1));
+        }
+        if c == b'\\' && i + 1 < bytes.len() {
+            let escape = bytes[i + 1];
+            i += 2;
+            match escape {
+                b'x' => {
+                    if i + 1 >= bytes.len() {
+                        return None;
+                    }
+                    let hex = std::str::from_utf8(&bytes[i..i + 2]).ok()?;
+                    let value = u8::from_str_radix(hex, 16).ok()?;
+                    decoded.push(value as char);
+                    i += 2;
+                }
+                b'n' => decoded.push('\n'),
+                b't' => decoded.push('\t'),
+                b'r' => decoded.push('\r'),
+                b'\\' => decoded.push('\\'),
+                b'"' => decoded.push('"'),
+                b'\'' => decoded.push('\''),
+                other => {
+                    decoded.push('\\');
+                    decoded.push(other as char);
+                }
+            }
+            continue;
+        }
+        decoded.push(c as char);
+        i += 1;
+    }
+    None
+}
+
+fn strip_block_comments(src: &str) -> String {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                if bytes[i] == b'\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                i += 2;
+            } else {
+                break;
+            }
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_with_only_supported_imports_passes() {
+        let src = r#"
+            import "pe"
+            import "hash"
+            rule supported {
+                strings: $a = "test"
+                condition: $a
+            }
+        "#;
+        assert!(audit_rule_source(Path::new("supported.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn double_quoted_magic_import_is_rejected() {
+        let src = "import \"magic\"\nrule bad { condition: magic.type() contains \"ELF\" }";
+        let err = audit_rule_source(Path::new("bad.yar"), src).unwrap_err();
+        match err {
+            Error::UnsupportedModule { module, path } => {
+                assert_eq!(module, "magic");
+                assert_eq!(path, Path::new("bad.yar"));
+            }
+            other => panic!("expected UnsupportedModule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_quoted_magic_import_is_also_rejected() {
+        let src = "import 'magic'\nrule bad { condition: true }";
+        let err = audit_rule_source(Path::new("bad.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn commented_out_magic_import_is_allowed() {
+        let src = "// import \"magic\"  -- left here for reference\nrule ok { condition: true }";
+        assert!(audit_rule_source(Path::new("ok.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn mix_of_imports_reports_the_forbidden_one() {
+        let src = r#"
+            import "pe"
+            import "hash"
+            import "magic"
+            import "math"
+            rule mixed { condition: true }
+        "#;
+        let err = audit_rule_source(Path::new("mixed.yar"), src).unwrap_err();
+        match err {
+            Error::UnsupportedModule { module, .. } => assert_eq!(module, "magic"),
+            other => panic!("expected UnsupportedModule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_source_passes() {
+        assert!(audit_rule_source(Path::new("empty.yar"), "").is_ok());
+    }
+
+    #[test]
+    fn whitespace_only_source_passes() {
+        assert!(audit_rule_source(Path::new("ws.yar"), "   \n\t\n  ").is_ok());
+    }
+
+    // Regression: previous version flagged block-commented imports as if they
+    // were real. yara-x ignores block comments, so the audit must too.
+    #[test]
+    fn block_commented_magic_import_is_allowed() {
+        let src = "/* import \"magic\" */\nrule ok { condition: true }";
+        assert!(audit_rule_source(Path::new("ok.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn multi_line_block_commented_magic_import_is_allowed() {
+        let src = "/*\n  import \"magic\"\n*/\nrule ok { condition: true }";
+        assert!(audit_rule_source(Path::new("ok.yar"), src).is_ok());
+    }
+
+    // Regression: previous version missed hex-escaped module names. yara-x
+    // decodes \xHH in string literals, so the audit must decode too.
+    #[test]
+    fn hex_escaped_magic_import_is_rejected() {
+        let src = "import \"ma\\x67ic\"\nrule bypass { condition: true }";
+        let err = audit_rule_source(Path::new("bypass.yar"), src).unwrap_err();
+        match err {
+            Error::UnsupportedModule { module, .. } => assert_eq!(module, "magic"),
+            other => panic!("expected UnsupportedModule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fully_hex_escaped_magic_import_is_rejected() {
+        let src = "import \"\\x6d\\x61\\x67\\x69\\x63\"\nrule bypass { condition: true }";
+        let err = audit_rule_source(Path::new("bypass.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn escaped_quote_inside_module_name_does_not_panic() {
+        // `import "ma\"gic"` (a quote inside the module name) does not match
+        // `magic` after decoding; should pass the audit.
+        let src = "import \"ma\\\"gic\"\nrule ok { condition: true }";
+        assert!(audit_rule_source(Path::new("ok.yar"), src).is_ok());
+    }
+
+    // Regression: previous line-by-line implementation missed
+    // `import\n"magic"` because the keyword and the string sat on different
+    // lines. yara-x's parser is whitespace insensitive so this audit must be
+    // too.
+    #[test]
+    fn newline_between_import_and_module_string_is_rejected() {
+        let src = "import\n\"magic\"\nrule x { condition: true }";
+        let err = audit_rule_source(Path::new("split.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn carriage_return_newline_between_import_and_module_string_is_rejected() {
+        let src = "import\r\n\"magic\"\nrule x { condition: true }";
+        let err = audit_rule_source(Path::new("crlf.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn block_comment_between_import_and_module_string_is_rejected() {
+        let src = "import /* hidden */ \"magic\"\nrule x { condition: true }";
+        let err = audit_rule_source(Path::new("midcomment.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn multi_line_block_comment_between_import_and_module_string_is_rejected() {
+        let src = "import /*\nignored\n*/ \"magic\"\nrule x { condition: true }";
+        let err = audit_rule_source(Path::new("midmulti.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn line_comment_between_import_keyword_and_string_is_rejected() {
+        let src = "import // skip me\n\"magic\"\nrule x { condition: true }";
+        let err = audit_rule_source(Path::new("midline.yar"), src).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    // The substring `import` appearing inside an identifier (e.g.
+    // `important_var`) or a string literal must NOT trigger the audit.
+    #[test]
+    fn import_substring_inside_identifier_does_not_false_flag() {
+        let src = "rule x { strings: $important_marker = \"magic\" condition: $important_marker }";
+        assert!(audit_rule_source(Path::new("subid.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn import_substring_inside_string_literal_does_not_false_flag() {
+        let src = "rule x { strings: $s = \"please import \\\"magic\\\"\" condition: $s }";
+        assert!(audit_rule_source(Path::new("substr.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn import_substring_inside_single_quoted_literal_does_not_false_flag() {
+        let src = "rule x { strings: $s = \"import 'magic' here\" condition: $s }";
+        assert!(audit_rule_source(Path::new("substr2.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn import_after_a_dot_identifier_does_not_false_flag() {
+        // `foo.import` shouldn't match because the `import` is not at a
+        // word boundary on the left.
+        let src = "rule x { condition: pe.imports(\"magic\") }";
+        assert!(audit_rule_source(Path::new("dot.yar"), src).is_ok());
+    }
+
+    #[test]
+    fn unterminated_import_string_does_not_panic() {
+        // A rule with a malformed import shouldn't crash the audit; yara-x
+        // will surface the real syntax error.
+        let src = "import \"magic\nrule bad { condition: true }";
+        let _ = audit_rule_source(Path::new("bad.yar"), src);
+    }
+
+    #[test]
+    fn truncated_block_comment_does_not_loop_forever() {
+        let src = "/* never closed\nrule should_be_swallowed { condition: true }";
+        let _ = audit_rule_source(Path::new("bad.yar"), src);
+    }
+
+    #[test]
+    fn strip_block_comments_preserves_line_numbers() {
+        let src = "rule a {}\n/* hidden\nstuff\nhere */rule b {}";
+        let stripped = strip_block_comments(src);
+        assert_eq!(stripped.lines().count(), 4);
+    }
+}

--- a/yara-backend/src/backend.rs
+++ b/yara-backend/src/backend.rs
@@ -1,0 +1,403 @@
+//! YaraBackend — the public facade.
+//!
+//! Two constructors:
+//! * [`YaraBackend::load_from_dir`] for rule directories (used by
+//!   fileanalyzer's yara_scan path).
+//! * [`YaraBackend::from_inline_sources`] for callers that ship rules as
+//!   string constants (mzhash, mzcount, xmzhash, mismatchminer, and
+//!   fileanalyzer/packed.rs).
+//!
+//! Scanning is via [`YaraBackend::scan_file`] or [`YaraBackend::scan_bytes`].
+//! Both internally call [`YaraBackend::reload_if_changed`] so the hot-reload
+//! contract is preserved without callers needing to track signatures.
+//!
+//! Concurrency: cheap to clone (`Arc`-backed); safe to share across worker
+//! threads. Each scan allocates a fresh `yara_x::Scanner` from the cached
+//! `Arc<Rules>`, which keeps multi-thread scans lock-free on the read path.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+
+use crate::cache::{self, CacheState, DirSignature};
+use crate::compile;
+use crate::error::{Error, Result};
+use crate::match_types::ScanReport;
+use crate::scan;
+
+#[derive(Debug)]
+pub struct YaraBackend {
+    rules_dir: Option<PathBuf>,
+    state: Arc<RwLock<CacheState>>,
+}
+
+impl YaraBackend {
+    /// Build a backend by walking a directory of `.yar`/`.yara` files.
+    ///
+    /// Returns `Err(LoadRules)` if the directory does not exist or cannot
+    /// be walked. Returns `Err(CompileFailed)` or `Err(UnsupportedModule)`
+    /// if any rule fails to compile (initial load is fail-fast).
+    pub fn load_from_dir<P: AsRef<Path>>(rules_dir: P) -> Result<Self> {
+        let dir = rules_dir.as_ref().to_path_buf();
+        if !dir.exists() {
+            return Err(Error::LoadRules {
+                dir,
+                reason: "directory does not exist".to_string(),
+            });
+        }
+        let files = compile::discover_rule_files(&dir).map_err(|e| Error::LoadRules {
+            dir: dir.clone(),
+            reason: format!("{e}"),
+        })?;
+        let signature = cache::signature_for_files(&files).map_err(|e| Error::LoadRules {
+            dir: dir.clone(),
+            reason: format!("{e}"),
+        })?;
+        let output = compile::compile_files(&files, true)?;
+        let n = output.rules.iter().count();
+        log::info!("yara-backend loaded {n} rule(s) from {}", dir.display());
+        let state = CacheState {
+            signature,
+            rules: output.rules,
+            compile_warnings: output.warnings,
+        };
+        Ok(YaraBackend {
+            rules_dir: Some(dir),
+            state: Arc::new(RwLock::new(state)),
+        })
+    }
+
+    /// Build a backend from inline `(namespace, source)` pairs.
+    ///
+    /// Intended for compile time string constants shipped inside a
+    /// caller crate (e.g. the inline rules in `mzhash`, `mzcount`,
+    /// `xmzhash`, `mismatchminer`, and `fileanalyzer/packed.rs`).
+    ///
+    /// Each source is capped at 16 MiB; passing something larger
+    /// returns [`Error::SourceTooLarge`] without touching the engine.
+    pub fn from_inline_sources(sources: &[(&str, &str)]) -> Result<Self> {
+        let rules = compile::compile_sources(sources)?;
+        let n = rules.iter().count();
+        log::debug!(
+            "yara-backend loaded {n} inline rule(s) from {} source(s)",
+            sources.len()
+        );
+        let state = CacheState {
+            signature: DirSignature::new(),
+            rules,
+            compile_warnings: Vec::new(),
+        };
+        Ok(YaraBackend {
+            rules_dir: None,
+            state: Arc::new(RwLock::new(state)),
+        })
+    }
+
+    /// Re-walk the rules directory and recompile if anything changed.
+    ///
+    /// Returns `Ok(true)` if a recompile happened, `Ok(false)` if no change
+    /// was detected. Returns `Ok(false)` immediately for inline-source
+    /// backends. On a successful recompile, individual bad rules become
+    /// warnings on `ScanReport::compile_warnings` rather than aborting.
+    pub fn reload_if_changed(&self) -> Result<bool> {
+        let Some(dir) = self.rules_dir.as_ref() else {
+            return Ok(false);
+        };
+        if !dir.exists() {
+            return Err(Error::RulesDirGone { dir: dir.clone() });
+        }
+        let files = compile::discover_rule_files(dir).map_err(|e| Error::LoadRules {
+            dir: dir.clone(),
+            reason: format!("{e}"),
+        })?;
+        let new_sig = cache::signature_for_files(&files).map_err(|e| Error::LoadRules {
+            dir: dir.clone(),
+            reason: format!("{e}"),
+        })?;
+        {
+            let state = self.state.read();
+            if state.signature == new_sig {
+                return Ok(false);
+            }
+        }
+        let output = compile::compile_files(&files, false)?;
+        let new_count = output.rules.iter().count();
+        let deadline = Duration::from_secs(5);
+        let mut state = self
+            .state
+            .try_write_for(deadline)
+            .ok_or(Error::CompileLockTimeout(deadline))?;
+        let prior_count = state.rules.iter().count();
+        // Defense in depth: if every file failed to compile (output is empty
+        // and warnings are present) but we had a working rule set before,
+        // keep the prior rules so a typo'd edit can't cause a silent
+        // detection blackout. The signature is still updated so we do not
+        // re-attempt the failing compile on every scan.
+        if new_count == 0 && !output.warnings.is_empty() && prior_count > 0 {
+            log::warn!(
+                "yara-backend reload produced 0 rules; keeping {prior_count} prior rule(s). Warnings: {:?}",
+                output.warnings
+            );
+            state.signature = new_sig;
+            state.compile_warnings = output.warnings;
+            return Ok(true);
+        }
+        log::info!(
+            "yara-backend reloaded {new_count} rule(s) from {}",
+            dir.display()
+        );
+        *state = CacheState {
+            signature: new_sig,
+            rules: output.rules,
+            compile_warnings: output.warnings,
+        };
+        Ok(true)
+    }
+
+    /// Scan a file. Pass `Duration::ZERO` to disable the timeout.
+    ///
+    /// The file is capped at 256 MiB; anything larger returns
+    /// [`Error::ScanInputTooLarge`] before yara-x is invoked.
+    pub fn scan_file<P: AsRef<Path>>(&self, path: P, timeout: Duration) -> Result<ScanReport> {
+        if let Err(e) = self.reload_if_changed() {
+            log::warn!("yara-backend reload failed: {e}; continuing with cached rules");
+        }
+        let (rules_arc, warnings) = {
+            let state = self.state.read();
+            (state.rules.clone(), state.compile_warnings.clone())
+        };
+        let path = path.as_ref();
+        let target = path.display().to_string();
+        scan::scan_file_with(&rules_arc, path, timeout, &target, warnings)
+    }
+
+    /// Scan a byte buffer. Pass `Duration::ZERO` to disable the timeout.
+    ///
+    /// The buffer is capped at 256 MiB; passing something larger
+    /// returns [`Error::ScanInputTooLarge`] without touching the
+    /// engine. Each call allocates a fresh short lived
+    /// `yara_x::Scanner`; high fan out workloads (eg `par_iter` over
+    /// thousands of small samples) are supported by design but the
+    /// per scan allocation cost is real and is caller visible.
+    pub fn scan_bytes(&self, data: &[u8], timeout: Duration) -> Result<ScanReport> {
+        if let Err(e) = self.reload_if_changed() {
+            log::warn!("yara-backend reload failed: {e}; continuing with cached rules");
+        }
+        let (rules_arc, warnings) = {
+            let state = self.state.read();
+            (state.rules.clone(), state.compile_warnings.clone())
+        };
+        scan::scan_bytes_with(&rules_arc, data, timeout, "<buffer>", warnings)
+    }
+
+    /// Count of compiled rules.
+    pub fn rule_count(&self) -> usize {
+        self.state.read().rules.iter().count()
+    }
+
+    /// Compiled rule names, in arbitrary order.
+    pub fn rule_names(&self) -> Vec<String> {
+        self.state
+            .read()
+            .rules
+            .iter()
+            .map(|r| r.identifier().to_string())
+            .collect()
+    }
+
+    /// Compile warnings produced during the most recent (re)load.
+    pub fn compile_warnings(&self) -> Vec<String> {
+        self.state.read().compile_warnings.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const MINIMAL: &str = "rule r1 { condition: true }";
+    const MZ: &str = r#"
+        rule mz_header {
+            strings: $mz = { 4D 5A }
+            condition: $mz at 0
+        }
+    "#;
+
+    fn mz_buf() -> Vec<u8> {
+        let mut v = vec![0u8; 32];
+        v[0] = 0x4D;
+        v[1] = 0x5A;
+        v
+    }
+
+    #[test]
+    fn load_from_dir_empty_dir_succeeds() {
+        let td = TempDir::new().unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert_eq!(b.rule_count(), 0);
+    }
+
+    #[test]
+    fn load_from_dir_missing_dir_errors_out() {
+        let phantom = std::path::Path::new("/never/exists/yara-backend-test");
+        let err = YaraBackend::load_from_dir(phantom).unwrap_err();
+        assert!(matches!(err, Error::LoadRules { .. }));
+    }
+
+    #[test]
+    fn load_from_dir_picks_up_rule_files() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join("a.yar"), MZ).unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert_eq!(b.rule_count(), 1);
+        assert!(b.rule_names().contains(&"mz_header".to_string()));
+    }
+
+    #[test]
+    fn load_from_dir_with_malformed_rule_fails_fast() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join("broken.yar"), "rule incomplete { strings:").unwrap();
+        let err = YaraBackend::load_from_dir(td.path()).unwrap_err();
+        assert!(matches!(err, Error::CompileFailed { .. }));
+    }
+
+    #[test]
+    fn from_inline_sources_compiles_one_rule() {
+        let b = YaraBackend::from_inline_sources(&[("default", MINIMAL)]).unwrap();
+        assert_eq!(b.rule_count(), 1);
+    }
+
+    #[test]
+    fn from_inline_sources_empty_list_succeeds() {
+        let b = YaraBackend::from_inline_sources(&[]).unwrap();
+        assert_eq!(b.rule_count(), 0);
+    }
+
+    #[test]
+    fn scan_bytes_returns_match_for_loaded_rule() {
+        let b = YaraBackend::from_inline_sources(&[("default", MZ)]).unwrap();
+        let r = b.scan_bytes(&mz_buf(), Duration::ZERO).unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.rule_names_sorted(), vec!["mz_header"]);
+    }
+
+    #[test]
+    fn scan_file_returns_match_for_loaded_rule() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("sample.bin");
+        fs::write(&p, mz_buf()).unwrap();
+        let b = YaraBackend::from_inline_sources(&[("default", MZ)]).unwrap();
+        let r = b.scan_file(&p, Duration::ZERO).unwrap();
+        assert_eq!(r.matches.len(), 1);
+    }
+
+    #[test]
+    fn reload_if_changed_returns_false_for_inline_backend() {
+        let b = YaraBackend::from_inline_sources(&[("default", MINIMAL)]).unwrap();
+        assert!(!b.reload_if_changed().unwrap());
+    }
+
+    #[test]
+    fn reload_if_changed_returns_false_when_dir_unchanged() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join("a.yar"), MZ).unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert!(!b.reload_if_changed().unwrap());
+    }
+
+    #[test]
+    fn reload_if_changed_returns_true_when_file_added() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join("a.yar"), MZ).unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert_eq!(b.rule_count(), 1);
+        fs::write(
+            td.path().join("b.yar"),
+            "rule b { strings: $x = \"x\" condition: $x }",
+        )
+        .unwrap();
+        assert!(b.reload_if_changed().unwrap());
+        assert_eq!(b.rule_count(), 2);
+    }
+
+    #[test]
+    fn reload_if_changed_returns_dir_gone_when_directory_disappears() {
+        let td = TempDir::new().unwrap();
+        let dir = td.path().to_path_buf();
+        fs::write(dir.join("a.yar"), MZ).unwrap();
+        let b = YaraBackend::load_from_dir(&dir).unwrap();
+        drop(td);
+        let err = b.reload_if_changed().unwrap_err();
+        assert!(matches!(err, Error::RulesDirGone { .. }));
+    }
+
+    #[test]
+    fn backend_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<YaraBackend>();
+        assert_send_sync::<Arc<YaraBackend>>();
+    }
+
+    #[test]
+    fn reload_keeps_prior_rules_when_every_file_breaks() {
+        use std::fs::OpenOptions;
+        use std::time::SystemTime;
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("a.yar");
+        fs::write(&path, MZ).unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert_eq!(b.rule_count(), 1);
+        // Corrupt the only rule file (incomplete syntax).
+        fs::write(&path, "rule broken { strings: $a = \"x\"").unwrap();
+        // Bump mtime deterministically so the signature definitely changes.
+        let f = OpenOptions::new().write(true).open(&path).unwrap();
+        f.set_modified(SystemTime::now() + Duration::from_secs(120))
+            .unwrap();
+        drop(f);
+        // Next scan triggers reload. The compile fails, but the prior rule
+        // is retained so the scan still matches.
+        let r = b.scan_bytes(&mz_buf(), Duration::ZERO).unwrap();
+        assert_eq!(
+            r.matches.len(),
+            1,
+            "prior rules must survive a fully-broken reload"
+        );
+        assert_eq!(b.rule_count(), 1);
+        // Warning surfaces so callers can show it to the operator.
+        assert!(!b.compile_warnings().is_empty());
+    }
+
+    #[test]
+    fn reload_to_empty_dir_clears_rules_intentionally() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("a.yar");
+        fs::write(&path, MZ).unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        assert_eq!(b.rule_count(), 1);
+        // User deliberately removes the rule file (no warning expected).
+        fs::remove_file(&path).unwrap();
+        let r = b.scan_bytes(&mz_buf(), Duration::ZERO).unwrap();
+        assert_eq!(r.matches.len(), 0, "intentional removal should clear rules");
+        assert_eq!(b.rule_count(), 0);
+        assert!(b.compile_warnings().is_empty());
+    }
+
+    #[test]
+    fn scan_picks_up_new_rule_dropped_into_dir() {
+        let td = TempDir::new().unwrap();
+        let b = YaraBackend::load_from_dir(td.path()).unwrap();
+        // Initially no rules; scan returns empty.
+        let r = b.scan_bytes(&mz_buf(), Duration::ZERO).unwrap();
+        assert_eq!(r.matches.len(), 0);
+        // Drop a rule into the dir.
+        fs::write(td.path().join("mz.yar"), MZ).unwrap();
+        // Next scan picks it up via the auto reload.
+        let r = b.scan_bytes(&mz_buf(), Duration::ZERO).unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.rule_names_sorted(), vec!["mz_header"]);
+    }
+}

--- a/yara-backend/src/cache.rs
+++ b/yara-backend/src/cache.rs
@@ -1,0 +1,137 @@
+//! Cache state for hot-reload.
+//!
+//! A directory signature is a `BTreeMap<PathBuf, (size, mtime)>` capturing
+//! every rule file's identity-from-the-filesystem's-point-of-view. Two
+//! signatures comparing equal means the rule set on disk has not changed
+//! since the last load. Two signatures comparing different means at least
+//! one file was added, removed, modified, or had its mtime bumped (e.g.
+//! by a `touch`) — and we should recompile.
+//!
+//! The signature uses size **and** mtime together so that filesystems with
+//! coarse mtime resolution (FAT32 = 2s) still detect changes that only
+//! affect content length. Two writes with the same size and same mtime
+//! tick would alias to one signature; that is a documented hot-reload
+//! limitation rather than a defect — at coarse-mtime resolution, no
+//! signature scheme without re-hashing every file can reliably detect
+//! that case.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use yara_x::Rules;
+
+pub(crate) type DirSignature = BTreeMap<PathBuf, (u64, SystemTime)>;
+
+#[derive(Debug)]
+pub(crate) struct CacheState {
+    pub signature: DirSignature,
+    pub rules: Arc<Rules>,
+    pub compile_warnings: Vec<String>,
+}
+
+/// Build a directory signature from a list of file paths.
+///
+/// Each file's metadata is fetched via `std::fs::metadata`, which follows
+/// symlinks. Files that fail to stat (e.g. removed between the WalkDir and
+/// this call) propagate as an `io::Error`; callers decide whether to retry
+/// or surface the failure.
+pub(crate) fn signature_for_files(files: &[PathBuf]) -> std::io::Result<DirSignature> {
+    let mut out = DirSignature::new();
+    for f in files {
+        let meta = std::fs::metadata(f)?;
+        let mtime = meta.modified()?;
+        out.insert(f.clone(), (meta.len(), mtime));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, OpenOptions};
+    use std::path::Path;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).expect("write");
+        p
+    }
+
+    #[test]
+    fn signature_is_empty_for_empty_list() {
+        let sig = signature_for_files(&[]).unwrap();
+        assert!(sig.is_empty());
+    }
+
+    #[test]
+    fn signature_is_stable_across_repeated_calls() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "a.yar", "rule a { condition: true }");
+        let sig1 = signature_for_files(std::slice::from_ref(&p)).unwrap();
+        let sig2 = signature_for_files(&[p]).unwrap();
+        assert_eq!(sig1, sig2);
+    }
+
+    #[test]
+    fn signature_changes_when_a_file_is_added() {
+        let td = TempDir::new().unwrap();
+        let a = write(td.path(), "a.yar", "rule a { condition: true }");
+        let sig_one = signature_for_files(std::slice::from_ref(&a)).unwrap();
+        let b = write(td.path(), "b.yar", "rule b { condition: true }");
+        let sig_two = signature_for_files(&[a, b]).unwrap();
+        assert_ne!(sig_one, sig_two);
+        assert_eq!(sig_one.len(), 1);
+        assert_eq!(sig_two.len(), 2);
+    }
+
+    #[test]
+    fn signature_changes_when_size_changes() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "r.yar", "rule a { condition: true }");
+        let sig1 = signature_for_files(std::slice::from_ref(&p)).unwrap();
+        write(td.path(), "r.yar", "rule longer_name { condition: true }");
+        let sig2 = signature_for_files(&[p]).unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn signature_changes_when_mtime_changes() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "r.yar", "rule a { condition: true }");
+        let sig1 = signature_for_files(std::slice::from_ref(&p)).unwrap();
+
+        let f = OpenOptions::new().write(true).open(&p).unwrap();
+        let bumped = SystemTime::now() + Duration::from_secs(120);
+        f.set_modified(bumped).expect("set_modified");
+        drop(f);
+
+        let sig2 = signature_for_files(&[p]).unwrap();
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn signature_propagates_io_error_on_missing_file() {
+        let td = TempDir::new().unwrap();
+        let phantom = td.path().join("never_existed.yar");
+        let res = signature_for_files(&[phantom]);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn signature_is_deterministic_across_input_orderings() {
+        let td = TempDir::new().unwrap();
+        let a = write(td.path(), "a.yar", "rule a { condition: true }");
+        let b = write(td.path(), "b.yar", "rule b { condition: true }");
+        let c = write(td.path(), "c.yar", "rule c { condition: true }");
+        let s1 = signature_for_files(&[a.clone(), b.clone(), c.clone()]).unwrap();
+        let s2 = signature_for_files(&[c, a, b]).unwrap();
+        assert_eq!(
+            s1, s2,
+            "BTreeMap key ordering should canonicalise the result"
+        );
+    }
+}

--- a/yara-backend/src/compile.rs
+++ b/yara-backend/src/compile.rs
@@ -1,0 +1,405 @@
+//! Rule discovery and compilation.
+//!
+//! Two entry points:
+//! * [`compile_files`] walks a list of paths, reads each one, audits it,
+//!   and adds it to a fresh yara-x compiler.
+//! * [`compile_sources`] takes already-loaded `(namespace, source)` pairs
+//!   and is the path inline-rule callers (mzhash, mzcount, xmzhash,
+//!   mismatchminer, fileanalyzer/packed.rs) will use.
+//!
+//! Both produce `Arc<yara_x::Rules>` so the result can be cheaply shared
+//! across worker threads.
+//!
+//! Strictness: `compile_files` takes a `fail_fast` flag. Initial loads pass
+//! `true` (any rule error aborts); reloads pass `false` (bad rules become
+//! warnings, good rules still compile). This mirrors the contract described
+//! in `cache.rs`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use walkdir::WalkDir;
+use yara_x::{Compiler, Rules};
+
+use crate::audit::audit_rule_source;
+use crate::error::{Error, Result};
+
+/// Hard cap on the size of any one rule source, inline or on disk. Real
+/// YARA corpora are kilobytes to a few megabytes; 16 MiB is comfortably
+/// generous while still keeping a runaway or adversarial source from
+/// exhausting memory.
+pub(crate) const MAX_RULE_SOURCE_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct CompileOutput {
+    pub rules: Arc<Rules>,
+    pub warnings: Vec<String>,
+}
+
+/// Walk `dir` and return every file whose extension is `.yar` or `.yara`
+/// (case-insensitive). Paths are returned sorted alphabetically so two
+/// successive walks of the same tree yield the same compile order.
+///
+/// Returns `Ok(vec![])` if the directory does not exist. Other I/O errors
+/// propagate; callers decide whether to treat them as fatal.
+pub(crate) fn discover_rule_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in WalkDir::new(dir) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if let Some(ext) = path.extension() {
+            let lower = ext.to_string_lossy().to_ascii_lowercase();
+            if lower == "yar" || lower == "yara" {
+                out.push(path.to_path_buf());
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Compile a set of rule files into a single `Rules` object.
+///
+/// If `fail_fast` is true the first error (I/O, audit, or compile)
+/// returns immediately as `Err`. If false, problems are appended to
+/// `CompileOutput::warnings` and compilation of the remaining files
+/// continues.
+pub(crate) fn compile_files(files: &[PathBuf], fail_fast: bool) -> Result<CompileOutput> {
+    let mut compiler = Compiler::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    for file in files {
+        match std::fs::metadata(file) {
+            Ok(meta) if meta.len() > MAX_RULE_SOURCE_BYTES => {
+                let err = Error::SourceTooLarge {
+                    name: file.display().to_string(),
+                    size: meta.len(),
+                    limit: MAX_RULE_SOURCE_BYTES,
+                };
+                if fail_fast {
+                    return Err(err);
+                }
+                warnings.push(err.to_string());
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                let msg = format!("could not stat {}: {e}", file.display());
+                if fail_fast {
+                    return Err(Error::CompileFailed {
+                        path: file.clone(),
+                        msg,
+                    });
+                }
+                warnings.push(msg);
+                continue;
+            }
+        }
+
+        let src = match std::fs::read_to_string(file) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("could not read {}: {e}", file.display());
+                if fail_fast {
+                    return Err(Error::CompileFailed {
+                        path: file.clone(),
+                        msg,
+                    });
+                }
+                warnings.push(msg);
+                continue;
+            }
+        };
+
+        if let Err(e) = audit_rule_source(file, &src) {
+            if fail_fast {
+                return Err(e);
+            }
+            warnings.push(e.to_string());
+            continue;
+        }
+
+        if let Err(e) = compiler.add_source(src.as_str()) {
+            let msg = format!("{e}");
+            if fail_fast {
+                return Err(Error::CompileFailed {
+                    path: file.clone(),
+                    msg,
+                });
+            }
+            warnings.push(format!("{}: {msg}", file.display()));
+        }
+    }
+
+    let rules = compiler.build();
+    Ok(CompileOutput {
+        rules: Arc::new(rules),
+        warnings,
+    })
+}
+
+/// Compile inline rule sources, each scoped to its own namespace.
+///
+/// Callers pass `(namespace, source)` pairs. Passing "default" for the
+/// namespace mirrors libyara's behavior when no namespace was set, which is
+/// what every existing inline-rule caller in MalChela does today.
+pub(crate) fn compile_sources(sources: &[(&str, &str)]) -> Result<Arc<Rules>> {
+    let mut compiler = Compiler::new();
+    for (namespace, src) in sources {
+        let src_len = src.len() as u64;
+        if src_len > MAX_RULE_SOURCE_BYTES {
+            return Err(Error::SourceTooLarge {
+                name: format!("<inline:{namespace}>"),
+                size: src_len,
+                limit: MAX_RULE_SOURCE_BYTES,
+            });
+        }
+        let virtual_path = PathBuf::from(format!("<inline:{namespace}>"));
+        audit_rule_source(&virtual_path, src)?;
+        compiler.new_namespace(namespace);
+        if let Err(e) = compiler.add_source(*src) {
+            return Err(Error::CompileFailed {
+                path: virtual_path,
+                msg: format!("{e}"),
+            });
+        }
+    }
+    Ok(Arc::new(compiler.build()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const MINIMAL_RULE: &str = r#"
+        rule minimal {
+            strings: $a = "marker"
+            condition: $a
+        }
+    "#;
+
+    const MAGIC_RULE: &str = r#"
+        import "magic"
+        rule uses_magic {
+            condition: magic.type() contains "ELF"
+        }
+    "#;
+
+    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).expect("write rule file");
+        p
+    }
+
+    #[test]
+    fn discover_returns_empty_for_missing_dir() {
+        let p = PathBuf::from("/definitely/does/not/exist/yara-backend-test");
+        let v = discover_rule_files(&p).expect("missing dir is ok");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn discover_returns_empty_for_empty_dir() {
+        let td = TempDir::new().unwrap();
+        let v = discover_rule_files(td.path()).unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn discover_picks_up_yar_and_yara_extensions() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "a.yar", MINIMAL_RULE);
+        write(td.path(), "b.yara", MINIMAL_RULE);
+        write(td.path(), "c.txt", "not a rule");
+        let v = discover_rule_files(td.path()).unwrap();
+        assert_eq!(v.len(), 2);
+        let names: Vec<String> = v
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"a.yar".to_string()));
+        assert!(names.contains(&"b.yara".to_string()));
+    }
+
+    #[test]
+    fn discover_is_case_insensitive_on_extension() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "x.YAR", MINIMAL_RULE);
+        write(td.path(), "y.Yara", MINIMAL_RULE);
+        write(td.path(), "z.YARA", MINIMAL_RULE);
+        let v = discover_rule_files(td.path()).unwrap();
+        assert_eq!(v.len(), 3);
+    }
+
+    #[test]
+    fn discover_walks_subdirectories() {
+        let td = TempDir::new().unwrap();
+        let nested = td.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+        write(td.path(), "top.yar", MINIMAL_RULE);
+        write(&nested, "deep.yar", MINIMAL_RULE);
+        let v = discover_rule_files(td.path()).unwrap();
+        assert_eq!(v.len(), 2);
+    }
+
+    #[test]
+    fn discover_results_are_sorted() {
+        let td = TempDir::new().unwrap();
+        write(td.path(), "z.yar", MINIMAL_RULE);
+        write(td.path(), "a.yar", MINIMAL_RULE);
+        write(td.path(), "m.yar", MINIMAL_RULE);
+        let v = discover_rule_files(td.path()).unwrap();
+        let names: Vec<String> = v
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["a.yar", "m.yar", "z.yar"]);
+    }
+
+    #[test]
+    fn compile_empty_list_produces_empty_rules() {
+        let out = compile_files(&[], true).unwrap();
+        assert!(out.warnings.is_empty());
+        assert!(out.rules.iter().next().is_none());
+    }
+
+    #[test]
+    fn compile_single_valid_file_succeeds() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "ok.yar", MINIMAL_RULE);
+        let out = compile_files(&[p], true).unwrap();
+        assert!(out.warnings.is_empty());
+        assert_eq!(out.rules.iter().count(), 1);
+    }
+
+    #[test]
+    fn compile_malformed_file_is_fatal_in_fail_fast_mode() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "bad.yar", "rule incomplete { strings:");
+        let err = compile_files(&[p], true).unwrap_err();
+        assert!(matches!(err, Error::CompileFailed { .. }));
+    }
+
+    #[test]
+    fn compile_malformed_file_becomes_warning_in_lenient_mode() {
+        let td = TempDir::new().unwrap();
+        let bad = write(td.path(), "bad.yar", "rule incomplete { strings:");
+        let good = write(td.path(), "ok.yar", MINIMAL_RULE);
+        let out = compile_files(&[bad, good], false).unwrap();
+        assert_eq!(out.warnings.len(), 1);
+        assert_eq!(out.rules.iter().count(), 1);
+    }
+
+    #[test]
+    fn compile_magic_import_is_fatal_in_fail_fast_mode() {
+        let td = TempDir::new().unwrap();
+        let p = write(td.path(), "magic.yar", MAGIC_RULE);
+        let err = compile_files(&[p], true).unwrap_err();
+        assert!(matches!(err, Error::UnsupportedModule { .. }));
+    }
+
+    #[test]
+    fn compile_magic_import_becomes_warning_in_lenient_mode() {
+        let td = TempDir::new().unwrap();
+        let bad = write(td.path(), "magic.yar", MAGIC_RULE);
+        let good = write(td.path(), "ok.yar", MINIMAL_RULE);
+        let out = compile_files(&[bad, good], false).unwrap();
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("magic"));
+        assert_eq!(out.rules.iter().count(), 1);
+    }
+
+    #[test]
+    fn compile_sources_inline_rule_succeeds() {
+        let arc = compile_sources(&[("default", MINIMAL_RULE)]).unwrap();
+        assert_eq!(arc.iter().count(), 1);
+    }
+
+    #[test]
+    fn compile_sources_malformed_returns_compile_failed() {
+        let err = compile_sources(&[("default", "rule incomplete {")]).unwrap_err();
+        assert!(matches!(err, Error::CompileFailed { .. }));
+    }
+
+    #[test]
+    fn compile_sources_multi_namespace_succeeds() {
+        let arc = compile_sources(&[
+            ("a", "rule one { condition: true }"),
+            ("b", "rule two { condition: true }"),
+        ])
+        .unwrap();
+        assert_eq!(arc.iter().count(), 2);
+    }
+
+    #[test]
+    fn compile_sources_same_rule_name_across_namespaces_is_allowed() {
+        let arc = compile_sources(&[
+            ("ns_a", "rule shared { condition: true }"),
+            ("ns_b", "rule shared { condition: true }"),
+        ])
+        .unwrap();
+        assert_eq!(arc.iter().count(), 2);
+    }
+
+    #[test]
+    fn compile_sources_rejects_oversized_inline_source() {
+        let oversized = "/* ".to_string()
+            + &"x".repeat(MAX_RULE_SOURCE_BYTES as usize + 16)
+            + " */ rule ok { condition: true }";
+        let err = compile_sources(&[("default", oversized.as_str())]).unwrap_err();
+        match err {
+            Error::SourceTooLarge { size, limit, name } => {
+                assert!(size > limit);
+                assert_eq!(limit, MAX_RULE_SOURCE_BYTES);
+                assert!(name.contains("default"));
+            }
+            other => panic!("expected SourceTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compile_sources_accepts_source_at_limit_boundary() {
+        // A 1 KiB source is well under the cap and must still compile.
+        let small = "rule small { condition: true }";
+        assert!(compile_sources(&[("default", small)]).is_ok());
+    }
+
+    #[test]
+    fn compile_files_rejects_oversized_rule_file_in_fail_fast() {
+        let td = TempDir::new().unwrap();
+        let p = td.path().join("huge.yar");
+        // Write a file just over the cap. Allocation cost is one big string
+        // in memory at write time; acceptable for a single test.
+        let huge = vec![b'x'; (MAX_RULE_SOURCE_BYTES + 1) as usize];
+        fs::write(&p, &huge).unwrap();
+        let err = compile_files(&[p], true).unwrap_err();
+        match err {
+            Error::SourceTooLarge { size, limit, .. } => {
+                assert!(size > limit);
+                assert_eq!(limit, MAX_RULE_SOURCE_BYTES);
+            }
+            other => panic!("expected SourceTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compile_files_skips_oversized_rule_file_in_lenient_mode() {
+        let td = TempDir::new().unwrap();
+        let huge = vec![b'x'; (MAX_RULE_SOURCE_BYTES + 1) as usize];
+        let big_path = td.path().join("huge.yar");
+        fs::write(&big_path, &huge).unwrap();
+        let good_path = write(td.path(), "ok.yar", MINIMAL_RULE);
+        let out = compile_files(&[big_path, good_path], false).unwrap();
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("limit"));
+        assert_eq!(out.rules.iter().count(), 1);
+    }
+}

--- a/yara-backend/src/error.rs
+++ b/yara-backend/src/error.rs
@@ -1,0 +1,125 @@
+//! Error types surfaced by yara-backend.
+//!
+//! Every variant carries enough context for a caller to render a useful
+//! message without consulting other state (which path failed, which target
+//! was being scanned, what the underlying engine said).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("YARA: failed to load rules from {}: {reason}", dir.display())]
+    LoadRules { dir: PathBuf, reason: String },
+
+    #[error("YARA: rule file {} failed to compile: {msg}", path.display())]
+    CompileFailed { path: PathBuf, msg: String },
+
+    #[error("YARA: rule file {} uses unsupported module `{module}`; rewrite or remove the rule", path.display())]
+    UnsupportedModule { path: PathBuf, module: String },
+
+    #[error("YARA: rule source `{name}` is {size} bytes; the limit is {limit} bytes")]
+    SourceTooLarge { name: String, size: u64, limit: u64 },
+
+    #[error("YARA: scan input `{target}` is {size} bytes; the limit is {limit} bytes")]
+    ScanInputTooLarge {
+        target: String,
+        size: u64,
+        limit: u64,
+    },
+
+    #[error("YARA: scan failed on {target}: {reason}")]
+    ScanFailed { target: String, reason: String },
+
+    #[error("YARA: scan timed out on {target} after {elapsed:?}")]
+    Timeout { target: String, elapsed: Duration },
+
+    #[error("YARA: rules directory disappeared: {}", dir.display())]
+    RulesDirGone { dir: PathBuf },
+
+    #[error("YARA: failed to acquire compile lock within {0:?}")]
+    CompileLockTimeout(Duration),
+
+    #[error("YARA: I/O error: {source}")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn display_load_rules_includes_path_and_reason() {
+        let err = Error::LoadRules {
+            dir: PathBuf::from("/tmp/rules"),
+            reason: "permission denied".to_string(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("/tmp/rules"), "expected path in: {s}");
+        assert!(s.contains("permission denied"), "expected reason in: {s}");
+    }
+
+    #[test]
+    fn display_compile_failed_includes_path_and_msg() {
+        let err = Error::CompileFailed {
+            path: PathBuf::from("rules/bad.yar"),
+            msg: "syntax error at line 3".to_string(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("bad.yar"), "expected path in: {s}");
+        assert!(s.contains("syntax error at line 3"), "expected msg in: {s}");
+    }
+
+    #[test]
+    fn display_unsupported_module_names_the_module() {
+        let err = Error::UnsupportedModule {
+            path: PathBuf::from("rules/uses_magic.yar"),
+            module: "magic".to_string(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("magic"), "expected module name in: {s}");
+        assert!(s.contains("uses_magic.yar"), "expected path in: {s}");
+    }
+
+    #[test]
+    fn display_timeout_shows_duration_and_target() {
+        let err = Error::Timeout {
+            target: "sample.bin".to_string(),
+            elapsed: Duration::from_secs(5),
+        };
+        let s = err.to_string();
+        assert!(s.contains("sample.bin"), "expected target in: {s}");
+        assert!(s.contains("5"), "expected duration digits in: {s}");
+    }
+
+    #[test]
+    fn display_compile_lock_timeout_shows_deadline() {
+        let err = Error::CompileLockTimeout(Duration::from_secs(5));
+        let s = err.to_string();
+        assert!(s.contains("5"), "expected deadline in: {s}");
+    }
+
+    #[test]
+    fn from_io_error_round_trips_through_source_chain() {
+        let io = io::Error::new(io::ErrorKind::NotFound, "missing");
+        let err: Error = io.into();
+        match err {
+            Error::Io { source } => assert_eq!(source.kind(), io::ErrorKind::NotFound),
+            other => panic!("expected Io variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Error>();
+        assert_send_sync::<Result<()>>();
+    }
+}

--- a/yara-backend/src/lib.rs
+++ b/yara-backend/src/lib.rs
@@ -1,0 +1,21 @@
+//! yara-backend — Rule loading and scanning facade backed by yara-x.
+//!
+//! Owns the YARA engine surface for MalChela's analysis tools. Caller crates
+//! import [`YaraBackend`], [`Match`], [`MatchedString`], [`ScanReport`],
+//! [`Error`], and [`Result`] from this crate rather than depending on `yara`
+//! or `yara_x` directly. This keeps the engine choice as a single point of
+//! change.
+//!
+//! See `README.md` for usage examples.
+
+pub use backend::YaraBackend;
+pub use error::{Error, Result};
+pub use match_types::{Match, MatchedString, ScanReport};
+
+mod audit;
+mod backend;
+mod cache;
+mod compile;
+mod error;
+mod match_types;
+mod scan;

--- a/yara-backend/src/match_types.rs
+++ b/yara-backend/src/match_types.rs
@@ -1,0 +1,144 @@
+//! Match and scan report types.
+//!
+//! `Match` carries every field the underlying engine surfaces; callers that
+//! only need rule names use [`ScanReport::rule_names_sorted`]. We keep the
+//! full surface so JSON serializers and future tooling can elide what they
+//! do not need rather than us re-introducing the field set later.
+//!
+//! Determinism: `meta` is a `BTreeMap`, never `HashMap`. `ScanReport::matches`
+//! is sorted at the wrapper boundary so two runs of the same scan produce
+//! byte identical reports.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Match {
+    pub rule_name: String,
+    pub namespace: String,
+    pub tags: Vec<String>,
+    pub matched_strings: Vec<MatchedString>,
+    pub meta: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedString {
+    pub identifier: String,
+    pub offset: u64,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScanReport {
+    pub matches: Vec<Match>,
+    pub elapsed: Duration,
+    pub rules_evaluated: usize,
+    pub compile_warnings: Vec<String>,
+}
+
+impl ScanReport {
+    /// Rule names only, alphabetically sorted, deduplicated.
+    ///
+    /// This is the convenience callers (notably fileanalyzer's JSON
+    /// serializer) reach for. Sorting + dedup at the wrapper guarantees
+    /// the same input produces the same output regardless of underlying
+    /// engine match order.
+    pub fn rule_names_sorted(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.matches.iter().map(|m| m.rule_name.clone()).collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    /// True iff the scan produced no matches.
+    pub fn is_empty(&self) -> bool {
+        self.matches.is_empty()
+    }
+}
+
+impl Default for ScanReport {
+    fn default() -> Self {
+        Self {
+            matches: Vec::new(),
+            elapsed: Duration::ZERO,
+            rules_evaluated: 0,
+            compile_warnings: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_match(rule_name: &str) -> Match {
+        Match {
+            rule_name: rule_name.to_string(),
+            namespace: "default".to_string(),
+            tags: Vec::new(),
+            matched_strings: Vec::new(),
+            meta: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn default_scan_report_is_empty() {
+        let r = ScanReport::default();
+        assert!(r.is_empty());
+        assert_eq!(r.matches.len(), 0);
+        assert_eq!(r.rules_evaluated, 0);
+        assert_eq!(r.elapsed, Duration::ZERO);
+        assert!(r.compile_warnings.is_empty());
+    }
+
+    #[test]
+    fn rule_names_sorted_empty_report_returns_empty() {
+        let r = ScanReport::default();
+        assert!(r.rule_names_sorted().is_empty());
+    }
+
+    #[test]
+    fn rule_names_sorted_alphabetic_ordering() {
+        let r = ScanReport {
+            matches: vec![mk_match("zebra"), mk_match("alpha"), mk_match("mango")],
+            ..ScanReport::default()
+        };
+        assert_eq!(r.rule_names_sorted(), vec!["alpha", "mango", "zebra"]);
+    }
+
+    #[test]
+    fn rule_names_sorted_dedups_consecutive_duplicates() {
+        let r = ScanReport {
+            matches: vec![mk_match("dup"), mk_match("dup"), mk_match("other")],
+            ..ScanReport::default()
+        };
+        assert_eq!(r.rule_names_sorted(), vec!["dup", "other"]);
+    }
+
+    #[test]
+    fn rule_names_sorted_dedups_after_sorting_not_in_input_order() {
+        let r = ScanReport {
+            matches: vec![mk_match("b"), mk_match("a"), mk_match("b"), mk_match("a")],
+            ..ScanReport::default()
+        };
+        assert_eq!(r.rule_names_sorted(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn meta_is_btreemap_not_hashmap() {
+        let mut m = mk_match("r");
+        m.meta.insert("z_key".to_string(), "z".to_string());
+        m.meta.insert("a_key".to_string(), "a".to_string());
+        m.meta.insert("m_key".to_string(), "m".to_string());
+        let keys: Vec<&String> = m.meta.keys().collect();
+        assert_eq!(keys, vec!["a_key", "m_key", "z_key"]);
+    }
+
+    #[test]
+    fn match_and_matched_string_are_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Match>();
+        assert_send_sync::<MatchedString>();
+        assert_send_sync::<ScanReport>();
+    }
+}

--- a/yara-backend/src/scan.rs
+++ b/yara-backend/src/scan.rs
@@ -1,0 +1,357 @@
+//! Scanning paths.
+//!
+//! These helpers wrap `yara_x::Scanner` so the rest of the crate works in
+//! terms of our own `ScanReport` and `Match` types. The `YaraBackend`
+//! facade calls into here once it has resolved the current `Arc<Rules>`
+//! from the cache.
+
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use yara_x::{MetaValue, Rules, Scanner};
+
+use crate::error::{Error, Result};
+use crate::match_types::{Match, MatchedString, ScanReport};
+
+/// Hard cap on the size of any single scan input, file or buffer. 256 MiB
+/// covers the largest realistic malware sample by a wide margin while
+/// keeping a runaway caller from passing the wrapper a multi gigabyte
+/// buffer that would dominate memory.
+pub(crate) const MAX_SCAN_INPUT_BYTES: u64 = 256 * 1024 * 1024;
+
+pub(crate) fn scan_file_with(
+    rules: &Arc<Rules>,
+    path: &Path,
+    timeout: Duration,
+    target: &str,
+    compile_warnings: Vec<String>,
+) -> Result<ScanReport> {
+    let size = std::fs::metadata(path)
+        .map_err(|e| Error::ScanFailed {
+            target: target.to_string(),
+            reason: format!("could not stat: {e}"),
+        })?
+        .len();
+    if size > MAX_SCAN_INPUT_BYTES {
+        return Err(Error::ScanInputTooLarge {
+            target: target.to_string(),
+            size,
+            limit: MAX_SCAN_INPUT_BYTES,
+        });
+    }
+    let start = Instant::now();
+    let rules_for_scanner = rules.clone();
+    let matches = run_scan_collect(target, move || {
+        let mut scanner = Scanner::new(rules_for_scanner.as_ref());
+        if !timeout.is_zero() {
+            scanner.set_timeout(timeout);
+        }
+        scanner
+            .scan_file(path)
+            .map(|results| collect_matches(&results))
+    })?
+    .map_err(|e| translate_scan_error(e, target, timeout))?;
+    let elapsed = start.elapsed();
+    Ok(ScanReport {
+        matches,
+        elapsed,
+        rules_evaluated: rules.iter().count(),
+        compile_warnings,
+    })
+}
+
+pub(crate) fn scan_bytes_with(
+    rules: &Arc<Rules>,
+    data: &[u8],
+    timeout: Duration,
+    target: &str,
+    compile_warnings: Vec<String>,
+) -> Result<ScanReport> {
+    let size = data.len() as u64;
+    if size > MAX_SCAN_INPUT_BYTES {
+        return Err(Error::ScanInputTooLarge {
+            target: target.to_string(),
+            size,
+            limit: MAX_SCAN_INPUT_BYTES,
+        });
+    }
+    let start = Instant::now();
+    let rules_for_scanner = rules.clone();
+    let matches = run_scan_collect(target, move || {
+        let mut scanner = Scanner::new(rules_for_scanner.as_ref());
+        if !timeout.is_zero() {
+            scanner.set_timeout(timeout);
+        }
+        scanner.scan(data).map(|results| collect_matches(&results))
+    })?
+    .map_err(|e| translate_scan_error(e, target, timeout))?;
+    let elapsed = start.elapsed();
+    Ok(ScanReport {
+        matches,
+        elapsed,
+        rules_evaluated: rules.iter().count(),
+        compile_warnings,
+    })
+}
+
+// Runs the scanner closure under catch_unwind so a yara-x panic on
+// adversarial input becomes a normal Error::ScanFailed rather than
+// aborting the calling process. The closure must convert yara-x's
+// borrowed ScanResults into owned data (Vec<Match>) before returning,
+// since the scanner's lifetime ends with the closure.
+//
+// AssertUnwindSafe is sound here because we discard the scanner after
+// any panic; no shared state is left observably inconsistent.
+fn run_scan_collect<F>(
+    target: &str,
+    f: F,
+) -> Result<std::result::Result<Vec<Match>, yara_x::ScanError>>
+where
+    F: FnOnce() -> std::result::Result<Vec<Match>, yara_x::ScanError>,
+{
+    panic::catch_unwind(AssertUnwindSafe(f)).map_err(|payload| {
+        let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+            (*s).to_string()
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "yara-x panicked with no string payload".to_string()
+        };
+        Error::ScanFailed {
+            target: target.to_string(),
+            reason: format!("internal panic: {msg}"),
+        }
+    })
+}
+
+fn translate_scan_error(e: yara_x::ScanError, target: &str, timeout: Duration) -> Error {
+    match e {
+        yara_x::ScanError::Timeout => Error::Timeout {
+            target: target.to_string(),
+            elapsed: timeout,
+        },
+        other => Error::ScanFailed {
+            target: target.to_string(),
+            reason: format!("{other}"),
+        },
+    }
+}
+
+fn collect_matches(results: &yara_x::ScanResults<'_, '_>) -> Vec<Match> {
+    let mut matches: Vec<Match> = results
+        .matching_rules()
+        .map(|rule| {
+            let mut meta: BTreeMap<String, String> = BTreeMap::new();
+            for (key, value) in rule.metadata() {
+                meta.insert(key.to_string(), meta_value_to_string(&value));
+            }
+            let tags: Vec<String> = rule.tags().map(|t| t.identifier().to_string()).collect();
+            let matched_strings: Vec<MatchedString> = rule
+                .patterns()
+                .flat_map(|pattern| {
+                    let ident = pattern.identifier().to_string();
+                    pattern.matches().map(move |m| MatchedString {
+                        identifier: ident.clone(),
+                        offset: m.range().start as u64,
+                        data: m.data().to_vec(),
+                    })
+                })
+                .collect();
+            Match {
+                rule_name: rule.identifier().to_string(),
+                namespace: rule.namespace().to_string(),
+                tags,
+                matched_strings,
+                meta,
+            }
+        })
+        .collect();
+    matches.sort_by(|a, b| {
+        a.rule_name
+            .cmp(&b.rule_name)
+            .then_with(|| a.namespace.cmp(&b.namespace))
+            .then_with(|| {
+                let a_off = a.matched_strings.first().map(|s| s.offset).unwrap_or(0);
+                let b_off = b.matched_strings.first().map(|s| s.offset).unwrap_or(0);
+                a_off.cmp(&b_off)
+            })
+    });
+    matches
+}
+
+fn meta_value_to_string(v: &MetaValue<'_>) -> String {
+    match v {
+        MetaValue::Integer(i) => i.to_string(),
+        MetaValue::Float(f) => f.to_string(),
+        MetaValue::Bool(b) => b.to_string(),
+        MetaValue::String(s) => (*s).to_string(),
+        MetaValue::Bytes(b) => format!("{b}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile::compile_sources;
+
+    const MZ_RULE: &str = r#"
+        rule mz_header {
+            strings: $mz = { 4D 5A }
+            condition: $mz at 0
+        }
+    "#;
+
+    const TAGGED_RULE: &str = r#"
+        rule tagged_rule : tag_a tag_b {
+            meta:
+                author = "test"
+                severity = 5
+                stable = true
+            strings: $a = "marker"
+            condition: $a
+        }
+    "#;
+
+    fn mz_bytes() -> Vec<u8> {
+        let mut v = vec![0u8; 60];
+        v[0] = 0x4D;
+        v[1] = 0x5A;
+        v
+    }
+
+    #[test]
+    fn scan_bytes_matches_mz_header() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let r = scan_bytes_with(&rules, &mz_bytes(), Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.matches[0].rule_name, "mz_header");
+        assert_eq!(r.matches[0].matched_strings.len(), 1);
+        assert_eq!(r.matches[0].matched_strings[0].offset, 0);
+        assert_eq!(r.matches[0].matched_strings[0].data, vec![0x4D, 0x5A]);
+    }
+
+    #[test]
+    fn scan_bytes_no_match_returns_empty() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let zeros = vec![0u8; 60];
+        let r = scan_bytes_with(&rules, &zeros, Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn scan_bytes_with_empty_buffer_returns_empty() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let r = scan_bytes_with(&rules, &[], Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn scan_with_no_rules_returns_empty_report() {
+        let rules = compile_sources(&[]).unwrap();
+        let r = scan_bytes_with(&rules, &mz_bytes(), Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert_eq!(r.rules_evaluated, 0);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn scan_file_matches_when_content_matches() {
+        let td = tempfile::TempDir::new().unwrap();
+        let p = td.path().join("sample.bin");
+        std::fs::write(&p, mz_bytes()).unwrap();
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let r = scan_file_with(&rules, &p, Duration::ZERO, "sample.bin", Vec::new()).unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.matches[0].rule_name, "mz_header");
+    }
+
+    #[test]
+    fn scan_file_missing_path_returns_scan_failed() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let phantom = Path::new("/definitely/does/not/exist/file.bin");
+        let err =
+            scan_file_with(&rules, phantom, Duration::ZERO, "phantom", Vec::new()).unwrap_err();
+        assert!(matches!(err, Error::ScanFailed { .. }));
+    }
+
+    #[test]
+    fn scan_report_carries_compile_warnings_through() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let warnings = vec!["one".to_string(), "two".to_string()];
+        let r =
+            scan_bytes_with(&rules, &mz_bytes(), Duration::ZERO, "buf", warnings.clone()).unwrap();
+        assert_eq!(r.compile_warnings, warnings);
+    }
+
+    #[test]
+    fn tags_and_meta_are_collected() {
+        let rules = compile_sources(&[("default", TAGGED_RULE)]).unwrap();
+        let buf = b"marker bytes here";
+        let r = scan_bytes_with(&rules, buf, Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert_eq!(r.matches.len(), 1);
+        let m = &r.matches[0];
+        assert!(m.tags.iter().any(|t| t == "tag_a"));
+        assert!(m.tags.iter().any(|t| t == "tag_b"));
+        assert_eq!(m.meta.get("author").map(String::as_str), Some("test"));
+        assert_eq!(m.meta.get("severity").map(String::as_str), Some("5"));
+        assert_eq!(m.meta.get("stable").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn multiple_matches_are_sorted_by_rule_name() {
+        const TWO_RULES: &str = r#"
+            rule zebra { strings: $z = "hit" condition: $z }
+            rule alpha { strings: $a = "hit" condition: $a }
+        "#;
+        let rules = compile_sources(&[("default", TWO_RULES)]).unwrap();
+        let r = scan_bytes_with(&rules, b"hit", Duration::ZERO, "buf", Vec::new()).unwrap();
+        assert_eq!(r.matches.len(), 2);
+        assert_eq!(r.matches[0].rule_name, "alpha");
+        assert_eq!(r.matches[1].rule_name, "zebra");
+        assert_eq!(r.rule_names_sorted(), vec!["alpha", "zebra"]);
+    }
+
+    #[test]
+    fn scan_bytes_rejects_oversized_buffer() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let oversized = vec![0u8; (MAX_SCAN_INPUT_BYTES + 1) as usize];
+        let err =
+            scan_bytes_with(&rules, &oversized, Duration::ZERO, "huge", Vec::new()).unwrap_err();
+        match err {
+            Error::ScanInputTooLarge {
+                size,
+                limit,
+                target,
+            } => {
+                assert!(size > limit);
+                assert_eq!(limit, MAX_SCAN_INPUT_BYTES);
+                assert_eq!(target, "huge");
+            }
+            other => panic!("expected ScanInputTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scan_file_rejects_oversized_file() {
+        let rules = compile_sources(&[("default", MZ_RULE)]).unwrap();
+        let td = tempfile::TempDir::new().unwrap();
+        let p = td.path().join("huge.bin");
+        let huge = vec![0u8; (MAX_SCAN_INPUT_BYTES + 1) as usize];
+        std::fs::write(&p, &huge).unwrap();
+        let err = scan_file_with(&rules, &p, Duration::ZERO, "huge.bin", Vec::new()).unwrap_err();
+        match err {
+            Error::ScanInputTooLarge {
+                size,
+                limit,
+                target,
+            } => {
+                assert!(size > limit);
+                assert_eq!(limit, MAX_SCAN_INPUT_BYTES);
+                assert_eq!(target, "huge.bin");
+            }
+            other => panic!("expected ScanInputTooLarge, got {other:?}"),
+        }
+    }
+}

--- a/yara-backend/tests/audit_evasion.rs
+++ b/yara-backend/tests/audit_evasion.rs
@@ -1,0 +1,73 @@
+//! Audit-evasion regression tests.
+//!
+//! These exercise corner cases an adversarial rule author might try when
+//! sneaking a yara-x-incompatible module past the pre-compile audit. The
+//! audit runs on both file-based and inline rule sources, and the evasion
+//! attempts that yara-x's own parser would still catch are documented as
+//! such (defense in depth).
+
+use yara_backend::{Error, YaraBackend};
+
+fn assert_unsupported_magic(res: Result<YaraBackend, Error>) {
+    match res {
+        Err(Error::UnsupportedModule { module, .. }) if module == "magic" => {}
+        Err(other) => panic!("expected UnsupportedModule(magic), got {other:?}"),
+        Ok(_) => panic!("expected audit to reject `magic` import, but compile succeeded"),
+    }
+}
+
+#[test]
+fn inline_audit_blocks_magic_with_extra_spaces() {
+    let src = r#"
+        import   "magic"
+        rule x { condition: true }
+    "#;
+    assert_unsupported_magic(YaraBackend::from_inline_sources(&[("default", src)]));
+}
+
+#[test]
+fn inline_audit_blocks_magic_with_tabs() {
+    let src = "\timport\t\t\"magic\"\nrule x { condition: true }";
+    assert_unsupported_magic(YaraBackend::from_inline_sources(&[("default", src)]));
+}
+
+#[test]
+fn inline_audit_blocks_magic_via_hex_escape() {
+    // \x6D decodes to 'm', so this is `import "magic"` once decoded.
+    let src = r#"
+        import "\x6Dagic"
+        rule x { condition: true }
+    "#;
+    assert_unsupported_magic(YaraBackend::from_inline_sources(&[("default", src)]));
+}
+
+#[test]
+fn inline_audit_does_not_false_flag_block_comment_with_magic() {
+    let src = r#"
+        /* This rule used to `import "magic"` and no longer does. */
+        rule benign { condition: true }
+    "#;
+    assert!(YaraBackend::from_inline_sources(&[("default", src)]).is_ok());
+}
+
+#[test]
+fn inline_audit_does_not_false_flag_line_comment_with_magic() {
+    let src = r#"
+        // import "magic"
+        rule benign { condition: true }
+    "#;
+    assert!(YaraBackend::from_inline_sources(&[("default", src)]).is_ok());
+}
+
+#[test]
+fn capitalised_magic_is_not_silently_accepted() {
+    // `Magic` is not a known yara-x module. yara-x will reject this as
+    // CompileFailed; we only assert the audit does not let it through
+    // as a successful load.
+    let src = r#"
+        import "Magic"
+        rule x { condition: true }
+    "#;
+    let res = YaraBackend::from_inline_sources(&[("default", src)]);
+    assert!(res.is_err(), "capitalised Magic must not load successfully");
+}

--- a/yara-backend/tests/chaos.rs
+++ b/yara-backend/tests/chaos.rs
@@ -1,0 +1,237 @@
+//! Chaos integration test.
+//!
+//! Spawns multiple worker threads that interleave random operations against
+//! a single shared `Arc<YaraBackend>`: rule file adds, removals, content
+//! corruption, scans of varying sizes, and explicit reload calls. Each
+//! operation must return a `Result` (no panics escape the wrapper) and the
+//! backend must never deadlock or corrupt its internal state.
+//!
+//! Determinism: every thread uses a seeded LCG, so a failure is
+//! reproducible from the thread id alone. The iteration count is small by
+//! default to keep CI fast; bump `OPS_PER_THREAD` locally if you want a
+//! longer soak. The seed is printed on failure so you can replay it.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use yara_backend::{Error, YaraBackend};
+
+const THREAD_COUNT: usize = 8;
+const OPS_PER_THREAD: usize = 250;
+const RULE_SLOTS: usize = 6;
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Lcg(seed)
+    }
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (self.0 >> 33) as u32
+    }
+    fn pick(&mut self, n: usize) -> usize {
+        (self.next_u32() as usize) % n
+    }
+}
+
+fn make_buffer(rng: &mut Lcg, max_len: usize) -> Vec<u8> {
+    let len = (rng.next_u32() as usize % max_len.max(1)) + 1;
+    let mut buf = vec![0u8; len];
+    for byte in buf.iter_mut() {
+        *byte = (rng.next_u32() & 0xFF) as u8;
+    }
+    if len >= 2 && rng.pick(3) == 0 {
+        buf[0] = 0x4D;
+        buf[1] = 0x5A;
+    }
+    buf
+}
+
+fn rule_body(slot: usize, marker: u32) -> String {
+    format!(
+        "rule chaos_slot_{slot} {{ meta: marker = \"{marker:08x}\" \
+         strings: $a = \"abcdef{slot:02}\" condition: $a }}"
+    )
+}
+
+fn malformed_body() -> &'static str {
+    "rule broken { strings: $a = \"oops"
+}
+
+#[derive(Debug, Default)]
+struct ThreadStats {
+    scans_ok: u32,
+    scans_err: u32,
+    reloads_ok: u32,
+    reloads_err: u32,
+    writes: u32,
+    deletes: u32,
+}
+
+fn worker(
+    tid: usize,
+    backend: Arc<YaraBackend>,
+    rules_dir: PathBuf,
+    slots: Arc<Vec<PathBuf>>,
+) -> ThreadStats {
+    let mut rng =
+        Lcg::new(0xCAFE_BABE_DEAD_BEEF ^ ((tid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)));
+    let mut stats = ThreadStats::default();
+    let _ = rules_dir;
+
+    for _ in 0..OPS_PER_THREAD {
+        match rng.pick(8) {
+            0 => {
+                // Drop a fresh well-formed rule into a slot.
+                let slot = rng.pick(RULE_SLOTS);
+                let body = rule_body(slot, rng.next_u32());
+                if fs::write(&slots[slot], body).is_ok() {
+                    stats.writes += 1;
+                }
+            }
+            1 => {
+                // Drop a malformed rule (the silent-blackout safety net is exercised).
+                let slot = rng.pick(RULE_SLOTS);
+                if fs::write(&slots[slot], malformed_body()).is_ok() {
+                    stats.writes += 1;
+                }
+            }
+            2 => {
+                // Delete a rule slot if it exists.
+                let slot = rng.pick(RULE_SLOTS);
+                if fs::remove_file(&slots[slot]).is_ok() {
+                    stats.deletes += 1;
+                }
+            }
+            3..=5 => {
+                // Random scan_bytes call (most common operation).
+                let buf = make_buffer(&mut rng, 4096);
+                match backend.scan_bytes(&buf, Duration::from_secs(5)) {
+                    Ok(_) => stats.scans_ok += 1,
+                    Err(Error::ScanFailed { .. })
+                    | Err(Error::Timeout { .. })
+                    | Err(Error::RulesDirGone { .. })
+                    | Err(Error::CompileLockTimeout(_)) => {
+                        stats.scans_err += 1;
+                    }
+                    Err(other) => {
+                        panic!("chaos thread {tid}: unexpected scan_bytes error class: {other:?}")
+                    }
+                }
+            }
+            6 => {
+                // Explicit reload (race with whatever is being written).
+                match backend.reload_if_changed() {
+                    Ok(_) => stats.reloads_ok += 1,
+                    Err(Error::RulesDirGone { .. })
+                    | Err(Error::CompileLockTimeout(_))
+                    | Err(Error::LoadRules { .. })
+                    | Err(Error::CompileFailed { .. })
+                    | Err(Error::UnsupportedModule { .. }) => stats.reloads_err += 1,
+                    Err(other) => {
+                        panic!("chaos thread {tid}: unexpected reload error class: {other:?}")
+                    }
+                }
+            }
+            _ => {
+                // scan_file against a fresh temp file (varies path each time).
+                let scratch =
+                    std::env::temp_dir().join(format!("yara_chaos_{tid}_{}.bin", rng.next_u32()));
+                let buf = make_buffer(&mut rng, 8192);
+                if fs::write(&scratch, &buf).is_ok() {
+                    match backend.scan_file(&scratch, Duration::from_secs(5)) {
+                        Ok(_) => stats.scans_ok += 1,
+                        Err(Error::ScanFailed { .. })
+                        | Err(Error::Timeout { .. })
+                        | Err(Error::RulesDirGone { .. })
+                        | Err(Error::CompileLockTimeout(_))
+                        | Err(Error::Io { .. }) => stats.scans_err += 1,
+                        Err(other) => panic!(
+                            "chaos thread {tid}: unexpected scan_file error class: {other:?}"
+                        ),
+                    }
+                    let _ = fs::remove_file(&scratch);
+                }
+            }
+        }
+    }
+    stats
+}
+
+#[test]
+fn chaos_threads_never_panic_or_deadlock() {
+    let td = TempDir::new().unwrap();
+    let rules_dir = td.path().to_path_buf();
+    let slots: Vec<PathBuf> = (0..RULE_SLOTS)
+        .map(|s| rules_dir.join(format!("slot_{s}.yar")))
+        .collect();
+    // Seed the dir with one good rule so load_from_dir doesn't see an empty dir.
+    fs::write(&slots[0], rule_body(0, 0xDEAD_BEEF)).unwrap();
+    let backend = Arc::new(YaraBackend::load_from_dir(&rules_dir).unwrap());
+    let slots = Arc::new(slots);
+
+    let mut handles = Vec::new();
+    for tid in 0..THREAD_COUNT {
+        let backend = backend.clone();
+        let rules_dir = rules_dir.clone();
+        let slots = slots.clone();
+        handles.push(thread::spawn(move || {
+            worker(tid, backend, rules_dir, slots)
+        }));
+    }
+
+    let mut totals = ThreadStats::default();
+    for h in handles {
+        let stats = h.join().expect("chaos thread panicked");
+        totals.scans_ok += stats.scans_ok;
+        totals.scans_err += stats.scans_err;
+        totals.reloads_ok += stats.reloads_ok;
+        totals.reloads_err += stats.reloads_err;
+        totals.writes += stats.writes;
+        totals.deletes += stats.deletes;
+    }
+
+    // The backend must still be usable after the storm.
+    let post_count = backend.rule_count();
+    let warnings = backend.compile_warnings();
+    eprintln!(
+        "chaos summary: scans_ok={}, scans_err={}, reloads_ok={}, reloads_err={}, writes={}, deletes={}, final_rule_count={}, warnings={}",
+        totals.scans_ok,
+        totals.scans_err,
+        totals.reloads_ok,
+        totals.reloads_err,
+        totals.writes,
+        totals.deletes,
+        post_count,
+        warnings.len(),
+    );
+
+    // After the storm settles, a fresh scan should still succeed.
+    let mut buf = vec![0u8; 64];
+    buf[0] = 0x4D;
+    buf[1] = 0x5A;
+    let report = backend
+        .scan_bytes(&buf, Duration::from_secs(5))
+        .expect("final scan must succeed");
+    // Sanity: rule names returned are unique and sorted.
+    let names = report.rule_names_sorted();
+    let unique: BTreeSet<_> = names.iter().cloned().collect();
+    assert_eq!(unique.len(), names.len(), "rule_names_sorted must dedup");
+    assert!(
+        names.windows(2).all(|w| w[0] <= w[1]),
+        "rule_names_sorted must be sorted"
+    );
+    assert!(
+        totals.scans_ok + totals.scans_err >= 100,
+        "chaos ran at least 100 scans across threads"
+    );
+}

--- a/yara-backend/tests/concurrency.rs
+++ b/yara-backend/tests/concurrency.rs
@@ -1,0 +1,106 @@
+//! Concurrency tests for YaraBackend.
+//!
+//! The Arc-backed state means many worker threads can scan the same backend
+//! at once; these tests assert that the scan path stays lock free on the
+//! read side and that the reload path is safe against contention.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use yara_backend::YaraBackend;
+
+const MZ_RULE: &str = r#"
+    rule mz_header {
+        strings: $mz = { 4D 5A }
+        condition: $mz at 0
+    }
+"#;
+
+fn make_mz_buffer(size: usize) -> Vec<u8> {
+    let mut v = vec![0u8; size];
+    v[0] = 0x4D;
+    v[1] = 0x5A;
+    v
+}
+
+#[test]
+fn many_threads_scanning_same_backend_get_identical_results() {
+    let backend = Arc::new(YaraBackend::from_inline_sources(&[("default", MZ_RULE)]).unwrap());
+    let buf = Arc::new(make_mz_buffer(4 * 1024 * 1024));
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let b = Arc::clone(&backend);
+        let data = Arc::clone(&buf);
+        handles.push(std::thread::spawn(move || {
+            let r = b.scan_bytes(&data, Duration::ZERO).expect("scan ok");
+            r.rule_names_sorted()
+        }));
+    }
+
+    let mut results = Vec::new();
+    for h in handles {
+        results.push(h.join().expect("thread joined"));
+    }
+
+    let expected = vec!["mz_header".to_string()];
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(r, &expected, "thread {i} produced a different result");
+    }
+}
+
+#[test]
+fn concurrent_reload_calls_do_not_deadlock_or_panic() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.yar"), MZ_RULE).unwrap();
+    let backend = Arc::new(YaraBackend::load_from_dir(tmp.path()).unwrap());
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let b = Arc::clone(&backend);
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..32 {
+                let _ = b.reload_if_changed();
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("reload thread joined");
+    }
+
+    assert_eq!(backend.rule_count(), 1);
+}
+
+#[test]
+fn readers_and_writer_share_the_backend_without_panicking() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("a.yar"), MZ_RULE).unwrap();
+    let backend = Arc::new(YaraBackend::load_from_dir(tmp.path()).unwrap());
+    let buf = Arc::new(make_mz_buffer(64 * 1024));
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let b = Arc::clone(&backend);
+        let data = Arc::clone(&buf);
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..32 {
+                let _ = b.scan_bytes(&data, Duration::ZERO);
+            }
+        }));
+    }
+
+    let b = Arc::clone(&backend);
+    let dir = tmp.path().to_path_buf();
+    handles.push(std::thread::spawn(move || {
+        for i in 0..8 {
+            let name = format!("extra_{i}.yar");
+            let body = format!("rule r_{i} {{ strings: $a = \"marker_{i}\" condition: $a }}");
+            std::fs::write(dir.join(&name), body).unwrap();
+            let _ = b.reload_if_changed();
+        }
+    }));
+
+    for h in handles {
+        h.join().expect("thread joined");
+    }
+}

--- a/yara-backend/tests/determinism.rs
+++ b/yara-backend/tests/determinism.rs
@@ -1,0 +1,93 @@
+//! Determinism tests for YaraBackend.
+//!
+//! Two scans of the same input must produce identical match data (rule
+//! names, namespaces, tags, metadata, matched bytes, and matched offsets).
+//! Wall clock fields like `elapsed` are excluded — those vary by design.
+
+use std::time::Duration;
+
+use yara_backend::{Match, ScanReport, YaraBackend};
+
+const TAGGED_RULE: &str = r#"
+    rule tagged_demo : alpha beta {
+        meta:
+            author = "test"
+            severity = 9
+            shipped = true
+        strings:
+            $a = "marker_alpha"
+            $b = "marker_beta"
+        condition: any of them
+    }
+"#;
+
+fn strip_timing(r: &ScanReport) -> Vec<Match> {
+    r.matches.clone()
+}
+
+#[test]
+fn two_runs_same_input_produce_identical_matches() {
+    let backend = YaraBackend::from_inline_sources(&[("default", TAGGED_RULE)]).unwrap();
+    let buf = b"some prefix marker_alpha and marker_beta here";
+    let r1 = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    let r2 = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    assert_eq!(strip_timing(&r1), strip_timing(&r2));
+    assert_eq!(r1.rules_evaluated, r2.rules_evaluated);
+    assert_eq!(r1.compile_warnings, r2.compile_warnings);
+}
+
+#[test]
+fn rule_names_sorted_helper_is_deterministic() {
+    const TWO_RULES: &str = r#"
+        rule zebra { strings: $a = "hit" condition: $a }
+        rule alpha { strings: $a = "hit" condition: $a }
+        rule mango { strings: $a = "hit" condition: $a }
+    "#;
+    let backend = YaraBackend::from_inline_sources(&[("default", TWO_RULES)]).unwrap();
+    let buf = b"hit";
+    let r1 = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    let r2 = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    let names1 = r1.rule_names_sorted();
+    let names2 = r2.rule_names_sorted();
+    assert_eq!(names1, names2);
+    assert_eq!(names1, vec!["alpha", "mango", "zebra"]);
+}
+
+#[test]
+fn metadata_iteration_order_is_alphabetic() {
+    let backend = YaraBackend::from_inline_sources(&[("default", TAGGED_RULE)]).unwrap();
+    let buf = b"marker_alpha";
+    let r = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    assert_eq!(r.matches.len(), 1);
+    let keys: Vec<&String> = r.matches[0].meta.keys().collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "BTreeMap should yield alphabetic keys");
+    assert_eq!(keys, vec!["author", "severity", "shipped"]);
+}
+
+#[test]
+fn matches_are_ordered_by_rule_name_alphabetically() {
+    const MULTI: &str = r#"
+        rule zulu { strings: $a = "x" condition: $a }
+        rule alpha { strings: $a = "x" condition: $a }
+        rule mike { strings: $a = "x" condition: $a }
+        rule bravo { strings: $a = "x" condition: $a }
+    "#;
+    let backend = YaraBackend::from_inline_sources(&[("default", MULTI)]).unwrap();
+    let r = backend.scan_bytes(b"x", Duration::ZERO).unwrap();
+    let names: Vec<&str> = r.matches.iter().map(|m| m.rule_name.as_str()).collect();
+    assert_eq!(names, vec!["alpha", "bravo", "mike", "zulu"]);
+}
+
+#[test]
+fn ten_runs_same_input_match_byte_for_byte() {
+    let backend = YaraBackend::from_inline_sources(&[("default", TAGGED_RULE)]).unwrap();
+    let buf = b"marker_alpha marker_beta";
+    let baseline = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+    let baseline_matches = strip_timing(&baseline);
+    for run in 1..10 {
+        let r = backend.scan_bytes(buf, Duration::ZERO).unwrap();
+        assert_eq!(strip_timing(&r), baseline_matches, "run {run} drifted");
+    }
+}

--- a/yara-backend/tests/file_rules.rs
+++ b/yara-backend/tests/file_rules.rs
@@ -1,0 +1,131 @@
+//! Integration tests for the file-based rule loading path using the
+//! committed fixtures in `tests/fixtures/rules/`.
+//!
+//! Unit tests in `src/compile.rs` and `src/backend.rs` already use temp
+//! directories built up at test time. These tests exercise the same path
+//! against the real on-disk fixtures so reviewers can see the rule files
+//! and trace the behaviour back to them.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use yara_backend::{Error, YaraBackend};
+
+fn fixture_dir(subdir: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(subdir);
+    p
+}
+
+fn copy_rules_to_tmp(rules: &[&str]) -> (tempfile::TempDir, PathBuf) {
+    let td = tempfile::TempDir::new().expect("tempdir");
+    let src = fixture_dir("rules");
+    for r in rules {
+        let from = src.join(r);
+        let to = td.path().join(r);
+        std::fs::copy(&from, &to).unwrap_or_else(|e| panic!("copy {r}: {e}"));
+    }
+    let path = td.path().to_path_buf();
+    (td, path)
+}
+
+#[test]
+fn load_from_dir_with_only_mz_header_compiles_one_rule() {
+    let (_td, dir) = copy_rules_to_tmp(&["mz_header.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    assert_eq!(b.rule_count(), 1);
+    assert!(b.rule_names().contains(&"mz_header".to_string()));
+}
+
+#[test]
+fn load_from_dir_with_multi_file_types_compiles_three_rules() {
+    let (_td, dir) = copy_rules_to_tmp(&["multi_file_types.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    assert_eq!(b.rule_count(), 3);
+    let names = b.rule_names();
+    assert!(names.contains(&"mz_header".to_string()));
+    assert!(names.contains(&"pdf_header".to_string()));
+    assert!(names.contains(&"zip_header".to_string()));
+}
+
+#[test]
+fn load_from_dir_with_tagged_rule_surfaces_tags_and_meta() {
+    let (_td, dir) = copy_rules_to_tmp(&["with_tags.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    let r = b
+        .scan_bytes(b"some prefix tagged-marker suffix", Duration::ZERO)
+        .unwrap();
+    assert_eq!(r.matches.len(), 1);
+    let m = &r.matches[0];
+    assert!(m.tags.iter().any(|t| t == "alpha"));
+    assert!(m.tags.iter().any(|t| t == "beta"));
+    assert!(m.tags.iter().any(|t| t == "gamma"));
+    assert_eq!(
+        m.meta.get("author").map(String::as_str),
+        Some("yara-backend tests")
+    );
+    assert_eq!(m.meta.get("severity").map(String::as_str), Some("5"));
+    assert_eq!(m.meta.get("stable").map(String::as_str), Some("true"));
+}
+
+#[test]
+fn load_from_dir_with_multi_namespace_file_compiles_both_rules() {
+    let (_td, dir) = copy_rules_to_tmp(&["multi_namespace.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    assert_eq!(b.rule_count(), 2);
+}
+
+#[test]
+fn load_from_dir_with_malformed_rule_fails_at_initial_load() {
+    let (_td, dir) = copy_rules_to_tmp(&["malformed.yar"]);
+    let err = YaraBackend::load_from_dir(&dir).unwrap_err();
+    assert!(matches!(err, Error::CompileFailed { .. }));
+}
+
+#[test]
+fn load_from_dir_with_uses_magic_fails_with_unsupported_module() {
+    let (_td, dir) = copy_rules_to_tmp(&["uses_magic.yar"]);
+    let err = YaraBackend::load_from_dir(&dir).unwrap_err();
+    match err {
+        Error::UnsupportedModule { module, path } => {
+            assert_eq!(module, "magic");
+            assert!(path.ends_with("uses_magic.yar"));
+        }
+        other => panic!("expected UnsupportedModule, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_from_dir_with_empty_file_compiles_clean() {
+    let (_td, dir) = copy_rules_to_tmp(&["empty.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    assert_eq!(b.rule_count(), 0);
+}
+
+#[test]
+fn load_from_dir_with_colliding_rule_names_across_files_fails() {
+    // mz_header.yar declares `mz_header`; multi_file_types.yar also
+    // declares `mz_header`. yara-x catches the duplicate at compile
+    // time and refuses the whole load. This documents the behaviour
+    // so future contributors do not assume rules across files are
+    // namespaced automatically.
+    let (_td, dir) = copy_rules_to_tmp(&["mz_header.yar", "multi_file_types.yar"]);
+    let err = YaraBackend::load_from_dir(&dir).unwrap_err();
+    assert!(matches!(err, Error::CompileFailed { .. }));
+}
+
+#[test]
+fn load_from_dir_with_non_colliding_good_rules_picks_up_all() {
+    // with_tags + multi_namespace have no overlapping rule names,
+    // so the load succeeds and produces one rule from with_tags plus
+    // two from multi_namespace.
+    let (_td, dir) = copy_rules_to_tmp(&["with_tags.yar", "multi_namespace.yar"]);
+    let b = YaraBackend::load_from_dir(&dir).unwrap();
+    assert_eq!(b.rule_count(), 3);
+    let names = b.rule_names();
+    assert!(names.contains(&"tagged_marker".to_string()));
+    assert!(names.contains(&"rule_one".to_string()));
+    assert!(names.contains(&"rule_two".to_string()));
+}

--- a/yara-backend/tests/fixtures/rules/malformed.yar
+++ b/yara-backend/tests/fixtures/rules/malformed.yar
@@ -1,0 +1,4 @@
+// Deliberately broken. Used by audit and compile error path tests.
+rule incomplete {
+    strings:
+        $a = "missing_closing_brace

--- a/yara-backend/tests/fixtures/rules/multi_file_types.yar
+++ b/yara-backend/tests/fixtures/rules/multi_file_types.yar
@@ -1,0 +1,28 @@
+// Matches MalChela mzcount / xmzhash inline rules. Detects MZ, PDF,
+// and ZIP magic numbers at offset 0.
+rule mz_header {
+    meta:
+        description = "Matches files with MZ header (Windows Executables)"
+    strings:
+        $mz = { 4D 5A }
+    condition:
+        $mz at 0
+}
+
+rule pdf_header {
+    meta:
+        description = "Matches files with PDF header"
+    strings:
+        $pdf = { 25 50 44 46 }
+    condition:
+        $pdf at 0
+}
+
+rule zip_header {
+    meta:
+        description = "Matches files with ZIP header"
+    strings:
+        $zip = { 50 4B 03 04 }
+    condition:
+        $zip at 0
+}

--- a/yara-backend/tests/fixtures/rules/multi_namespace.yar
+++ b/yara-backend/tests/fixtures/rules/multi_namespace.yar
@@ -1,0 +1,16 @@
+// Two rules in one file. yara-x compiles them under the same
+// namespace (the default) when loaded via load_from_dir; that
+// mirrors libyara's behaviour when no namespace is set.
+rule rule_one {
+    strings:
+        $a = "marker-one"
+    condition:
+        $a
+}
+
+rule rule_two {
+    strings:
+        $b = "marker-two"
+    condition:
+        $b
+}

--- a/yara-backend/tests/fixtures/rules/mz_header.yar
+++ b/yara-backend/tests/fixtures/rules/mz_header.yar
@@ -1,0 +1,10 @@
+// Matches MalChela mzhash / mismatchminer inline rule. Detects the
+// MZ header at offset 0 (Windows executables).
+rule mz_header {
+    meta:
+        description = "Matches files with MZ header (Windows Executables)"
+    strings:
+        $mz = { 4D 5A }
+    condition:
+        $mz at 0
+}

--- a/yara-backend/tests/fixtures/rules/uses_magic.yar
+++ b/yara-backend/tests/fixtures/rules/uses_magic.yar
@@ -1,0 +1,9 @@
+// Uses the libyara-only `magic` module. yara-x does not implement
+// magic, so the audit pass refuses this file with UnsupportedModule
+// before it ever reaches the engine.
+import "magic"
+
+rule magic_user {
+    condition:
+        magic.type() contains "ELF"
+}

--- a/yara-backend/tests/fixtures/rules/with_tags.yar
+++ b/yara-backend/tests/fixtures/rules/with_tags.yar
@@ -1,0 +1,12 @@
+// Exercises tags and metadata. The wrapper must surface both lists
+// for any caller that wants them later.
+rule tagged_marker : alpha beta gamma {
+    meta:
+        author = "yara-backend tests"
+        severity = 5
+        stable = true
+    strings:
+        $a = "tagged-marker"
+    condition:
+        $a
+}

--- a/yara-backend/tests/fixtures/samples/README.md
+++ b/yara-backend/tests/fixtures/samples/README.md
@@ -1,0 +1,19 @@
+# Synthetic test samples
+
+This directory used to ship binary fixture files. We switched to generating
+them inside the test code so the repo stays text-only and reviewers do not
+have to inspect raw bytes.
+
+The helpers in `tests/*.rs` produce three shapes:
+
+- `make_mz_buffer(size)` returns a buffer whose first two bytes are `4D 5A`
+  (MZ header) and the rest are zero. Used to exercise the `mz_header` rule.
+- `make_pdf_buffer(size)` returns a buffer whose first four bytes are
+  `25 50 44 46` (`%PDF`). Used to exercise the `pdf_header` rule.
+- `make_zip_buffer(size)` returns a buffer whose first four bytes are
+  `50 4B 03 04` (PK\x03\x04). Used to exercise the `zip_header` rule.
+
+A deterministic LCG is used for any larger filler bytes so two runs of the
+same test see the same bytes. No malware bytes are present in any sample,
+ever. The samples are byte shapes that match the rule's pattern, not
+executable code.

--- a/yara-backend/tests/inline_rules.rs
+++ b/yara-backend/tests/inline_rules.rs
@@ -1,0 +1,178 @@
+//! Inline rule regression tests.
+//!
+//! Each MalChela consumer that uses an inline rule string today has a test
+//! here. The rule body is copied verbatim from the consumer so that any
+//! drift between the upstream source and what yara-backend can compile
+//! would break the test.
+//!
+//! When a caller migrates to yara-backend in a later PR, its existing
+//! inline rule string is replaced by a call to
+//! `YaraBackend::from_inline_sources(...)` and the same rule body is
+//! passed in. These tests prove the body still compiles and scans the
+//! same way under yara-x.
+
+use std::time::Duration;
+
+use yara_backend::YaraBackend;
+
+fn fill_zero(size: usize) -> Vec<u8> {
+    vec![0u8; size]
+}
+
+fn make_mz_buffer(size: usize) -> Vec<u8> {
+    let mut v = fill_zero(size);
+    v[0] = 0x4D;
+    v[1] = 0x5A;
+    v
+}
+
+fn make_pdf_buffer(size: usize) -> Vec<u8> {
+    let mut v = fill_zero(size);
+    v[0..4].copy_from_slice(b"%PDF");
+    v
+}
+
+fn make_zip_buffer(size: usize) -> Vec<u8> {
+    let mut v = fill_zero(size);
+    v[0..4].copy_from_slice(&[0x50, 0x4B, 0x03, 0x04]);
+    v
+}
+
+// ─── mzhash and mismatchminer (single MZ rule) ──────────────────────────
+const MZHASH_RULE: &str = r#"
+rule mz_header {
+    meta:
+        description = "Matches files with MZ header (Windows Executables)"
+    strings:
+        $mz = {4D 5A}
+    condition:
+        $mz at 0
+}
+"#;
+
+#[test]
+fn mzhash_inline_rule_compiles_and_matches_mz_files() {
+    let b = YaraBackend::from_inline_sources(&[("default", MZHASH_RULE)]).unwrap();
+    assert_eq!(b.rule_count(), 1);
+
+    let r = b.scan_bytes(&make_mz_buffer(64), Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["mz_header"]);
+
+    let r = b.scan_bytes(&fill_zero(64), Duration::ZERO).unwrap();
+    assert!(r.is_empty());
+}
+
+#[test]
+fn mismatchminer_inline_rule_is_identical_to_mzhash() {
+    // mismatchminer ships the same inline rule body. This test guards
+    // against the bodies drifting apart between commits.
+    let b = YaraBackend::from_inline_sources(&[("default", MZHASH_RULE)]).unwrap();
+    let r = b.scan_bytes(&make_mz_buffer(32), Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["mz_header"]);
+}
+
+// ─── mzcount and xmzhash (three-magic-number rule) ──────────────────────
+const MZCOUNT_RULE: &str = r#"
+rule mz_header {
+    meta:
+        description = "Matches files with MZ header (Windows Executables)"
+    strings:
+        $mz = {4D 5A}
+    condition:
+        $mz at 0
+}
+
+rule pdf_header {
+    meta:
+        description = "Matches files with PDF header"
+    strings:
+        $pdf = {25 50 44 46}
+    condition:
+        $pdf at 0
+}
+
+rule zip_header {
+    meta:
+        description = "Matches files with ZIP header"
+    strings:
+        $zip = {50 4B 03 04}
+    condition:
+        $zip at 0
+}
+"#;
+
+#[test]
+fn mzcount_inline_rule_picks_up_each_magic_number() {
+    let b = YaraBackend::from_inline_sources(&[("default", MZCOUNT_RULE)]).unwrap();
+    assert_eq!(b.rule_count(), 3);
+
+    let r = b.scan_bytes(&make_mz_buffer(64), Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["mz_header"]);
+
+    let r = b.scan_bytes(&make_pdf_buffer(64), Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["pdf_header"]);
+
+    let r = b.scan_bytes(&make_zip_buffer(64), Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["zip_header"]);
+
+    let r = b.scan_bytes(&fill_zero(64), Duration::ZERO).unwrap();
+    assert!(r.is_empty());
+}
+
+#[test]
+fn xmzhash_inline_rule_is_identical_to_mzcount() {
+    // Same three-rule body. Guard against drift.
+    let b = YaraBackend::from_inline_sources(&[("default", MZCOUNT_RULE)]).unwrap();
+    assert_eq!(b.rule_count(), 3);
+}
+
+// ─── fileanalyzer/packed.rs (packer detection) ──────────────────────────
+//
+// The packed.rs rule is larger and uses byte patterns with wildcards
+// plus a uint16(0) numeric check. yara-x supports both features. We
+// trim the test to a minimal scan that exercises the simple substring
+// strings (UPX, PECompact, etc.) so we do not depend on a real packed
+// binary fixture.
+const PACKED_RULE: &str = r#"
+rule is_packed {
+    meta:
+        description = "Detects packed executables (UPX, etc.)"
+    strings:
+        $upx_sig1 = "UPX!"
+        $packer_str1 = "UPX"
+        $packer_str2 = "PECompact"
+        $packer_str3 = "ASPack"
+    condition:
+        any of them
+}
+"#;
+
+#[test]
+fn packed_inline_rule_compiles() {
+    let b = YaraBackend::from_inline_sources(&[("default", PACKED_RULE)]).unwrap();
+    assert_eq!(b.rule_count(), 1);
+}
+
+#[test]
+fn packed_inline_rule_fires_on_upx_signature_string() {
+    let b = YaraBackend::from_inline_sources(&[("default", PACKED_RULE)]).unwrap();
+    let buf = b"random prefix UPX! and more bytes";
+    let r = b.scan_bytes(buf, Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["is_packed"]);
+}
+
+#[test]
+fn packed_inline_rule_fires_on_pecompact_signature() {
+    let b = YaraBackend::from_inline_sources(&[("default", PACKED_RULE)]).unwrap();
+    let buf = b"some prefix PECompact tail";
+    let r = b.scan_bytes(buf, Duration::ZERO).unwrap();
+    assert_eq!(r.rule_names_sorted(), vec!["is_packed"]);
+}
+
+#[test]
+fn packed_inline_rule_no_match_on_clean_bytes() {
+    let b = YaraBackend::from_inline_sources(&[("default", PACKED_RULE)]).unwrap();
+    let buf = fill_zero(128);
+    let r = b.scan_bytes(&buf, Duration::ZERO).unwrap();
+    assert!(r.is_empty());
+}

--- a/yara-backend/tests/readme_examples.rs
+++ b/yara-backend/tests/readme_examples.rs
@@ -1,0 +1,60 @@
+//! Verifies that the code snippets in `README.md` actually compile and run.
+//!
+//! When the README changes, transcribe the new snippet here and adjust any
+//! surrounding setup (temp dirs, fixture files) needed to make it executable.
+//! If a snippet drifts away from working code, this test catches it.
+
+use std::fs;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use yara_backend::YaraBackend;
+
+#[test]
+fn readme_quick_start_load_from_dir_compiles_and_runs() {
+    // The README example reads from "./yara_rules"; for the test we use a
+    // tempdir and a synthetic sample so it stays hermetic.
+    let td = TempDir::new().unwrap();
+    fs::write(
+        td.path().join("mz.yar"),
+        "rule mz_header { strings: $mz = { 4D 5A } condition: $mz at 0 }",
+    )
+    .unwrap();
+    let mut sample = vec![0u8; 64];
+    sample[0] = 0x4D;
+    sample[1] = 0x5A;
+    let sample_path = td.path().join("sample.bin");
+    fs::write(&sample_path, &sample).unwrap();
+
+    // --- README snippet (rules-dir example) ---
+    let backend = YaraBackend::load_from_dir(td.path()).unwrap();
+    let report = backend
+        .scan_file(&sample_path, Duration::from_secs(5))
+        .unwrap();
+    let mut matched: Vec<String> = Vec::new();
+    for name in report.rule_names_sorted() {
+        matched.push(name);
+    }
+    // --- end snippet ---
+
+    assert_eq!(matched, vec!["mz_header"]);
+}
+
+#[test]
+fn readme_quick_start_inline_example_compiles_and_runs() {
+    // --- README snippet (inline-rules example) ---
+    const MZ_RULE: &str = r#"
+        rule mz_header {
+            strings: $mz = { 4D 5A }
+            condition: $mz at 0
+        }
+    "#;
+
+    let backend = YaraBackend::from_inline_sources(&[("default", MZ_RULE)]).unwrap();
+    let mut sample = vec![0u8; 64];
+    sample[0] = 0x4D;
+    sample[1] = 0x5A;
+    let report = backend.scan_bytes(&sample, Duration::ZERO).unwrap();
+    assert_eq!(report.rule_names_sorted(), vec!["mz_header"]);
+    // --- end snippet ---
+}

--- a/yara-backend/tools/audit_yara_rules.sh
+++ b/yara-backend/tools/audit_yara_rules.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# audit_yara_rules.sh - shell mirror of yara-backend's src/audit.rs
+#
+# Walks a directory of .yar / .yara files and refuses any rule that
+# imports a module yara-x does not implement. Intended for use as a
+# CI pre-build hook so unsupported rules are caught before cargo
+# tries to compile them.
+#
+# Matches the Rust audit's parsing semantics:
+#   * `/* ... */` block comments are stripped before scanning so a
+#     commented-out import is not flagged.
+#   * `//` line comments are stripped before scanning.
+#   * Whitespace between the `import` keyword and the module string
+#     can include newlines / carriage returns (yara-x is whitespace
+#     insensitive between tokens, so this audit must be too).
+#
+# Limitation: this script does not decode `\xHH` style escapes inside
+# import strings. Rules like `import "ma\x67ic"` will slip through
+# the shell audit but are caught by the Rust audit at compile time,
+# so the result is still correct. The Rust audit (src/audit.rs) is
+# authoritative for tricky cases; this script is the fast first pass.
+#
+# Exit codes:
+#   0 - clean (every rule uses only supported imports)
+#   1 - one or more rules use a forbidden import
+#   2 - usage error (directory does not exist or argument missing)
+#
+# Usage:
+#   tools/audit_yara_rules.sh [<rules_dir>]
+#
+# If <rules_dir> is omitted it defaults to ./yara_rules
+
+set -eu
+
+# Modules yara-x does not implement. Keep this list in sync with
+# FORBIDDEN_IMPORTS in src/audit.rs.
+FORBIDDEN_MODULES=(
+    "magic"
+)
+
+RULES_DIR="${1:-yara_rules}"
+
+if [ ! -d "$RULES_DIR" ]; then
+    echo "audit_yara_rules: directory not found: $RULES_DIR" >&2
+    exit 2
+fi
+
+# Strip /* ... */ block comments AND // line comments, then collapse all
+# whitespace runs (including newlines) to a single space so the grep
+# pattern matches multi-line `import\n"magic"` the same way yara-x does.
+# Implemented in awk so the script stays portable across macOS / Linux
+# without GNU sed extensions.
+normalise_source() {
+    awk '
+        BEGIN { in_block = 0 }
+        {
+            line = $0
+            out = ""
+            i = 1
+            n = length(line)
+            while (i <= n) {
+                if (in_block) {
+                    rest = substr(line, i)
+                    p = index(rest, "*/")
+                    if (p > 0) {
+                        i = i + p + 1
+                        in_block = 0
+                    } else {
+                        i = n + 1
+                    }
+                } else {
+                    rest = substr(line, i)
+                    p = index(rest, "/*")
+                    lp = index(rest, "//")
+                    if (lp > 0 && (p == 0 || lp < p)) {
+                        out = out substr(line, i, lp - 1)
+                        i = n + 1
+                    } else if (p > 0) {
+                        out = out substr(line, i, p - 1)
+                        i = i + p + 1
+                        in_block = 1
+                    } else {
+                        out = out substr(line, i)
+                        i = n + 1
+                    }
+                }
+            }
+            print out
+        }
+    ' "$1" | tr '\n\r\t' '   ' | tr -s ' '
+}
+
+hits=0
+while IFS= read -r -d '' f; do
+    cleaned=$(normalise_source "$f")
+    # Match `import` at a word boundary that is NOT inside a string literal
+    # (preceded by `"` or `'`). The Rust audit handles string literal scoping
+    # precisely; this is the shell first pass.
+    for forbidden in "${FORBIDDEN_MODULES[@]}"; do
+        if printf '%s\n' "$cleaned" \
+            | grep -qE "(^|[^A-Za-z0-9_\"'])import +[\"']${forbidden}[\"']"; then
+            echo "audit_yara_rules: $f imports unsupported module \`$forbidden\`" >&2
+            hits=$((hits + 1))
+        fi
+    done
+done < <(find "$RULES_DIR" -type f \( -iname '*.yar' -o -iname '*.yara' \) -print0)
+
+if [ "$hits" -gt 0 ]; then
+    echo "audit_yara_rules: $hits rule file(s) use unsupported imports" >&2
+    exit 1
+fi
+
+echo "audit_yara_rules: ok (every rule file under $RULES_DIR uses supported imports only)"
+exit 0


### PR DESCRIPTION
MalChela tools currently link against the libyara C library via the `yara` crate. libyara is the main blocker for a native Windows build and slows clean cargo builds because of the C compile step.

This new workspace crate (`yara-backend`) wraps `yara-x`, VirusTotal's pure-Rust YARA reimplementation, behind a small high-level API. Once the tools migrate to it (later PRs), the libyara dependency can be dropped entirely.

This PR adds only the crate. No existing MalChela tool is touched. `tools.yaml`, `yara_rules/`, `server/`, and `detections.yaml` are untouched. The only change outside `yara-backend/` is a one-line append to the workspace `Cargo.toml` members list.

What the crate gives you

* `YaraBackend::load_from_dir(path)` walks a directory of `.yar` / `.yara` files and compiles them.
* `YaraBackend::from_inline_sources(&[(ns, src)])` compiles inline rule strings (the pattern `mzhash`, `mzcount`, `xmzhash`, `mismatchminer`, and `fileanalyzer/packed.rs` use today).
* `scan_file(path, timeout)` and `scan_bytes(buf, timeout)` produce a `ScanReport` with sorted matches, elapsed time, and any compile warnings from the most recent reload.
* `ScanReport::rule_names_sorted()` is the helper the JSON layer reaches for so output stays stable byte for byte across runs.

Hot reload still works the way you expect: every scan first checks the rules directory for changes (file size + mtime per file). If anything changed, the backend recompiles and atomically swaps the rule set. Operators can drop a new `.yar` into `yara_rules/` and the next scan picks it up with no rebuild.

Defensive choices

* Hard size caps at the public API boundary: 16 MiB per rule source, 256 MiB per scan input. Checked via `fs::metadata().len()` before any allocation, surfaced as dedicated error variants.
* If a reload would empty the entire rule set because every file failed to compile, the backend keeps the prior known good rules and surfaces the compile warnings. This avoids a silent detection blackout when an operator typos a rule mid edit.
* Audit (runs before compilation) refuses rules importing modules yara-x does not implement (`magic` today). It walks the source as a single byte stream rather than line by line, so it catches every form yara-x's own parser accepts: block comments, line comments, hex escapes, tabs, runs of spaces, and even an `import` keyword on one line with the module string on the next. The `import` keyword is matched at a word boundary so `pe.imports(...)` and a variable named `$import_var` do not false-flag.
* Scan path wraps yara-x calls in `panic::catch_unwind` and converts the result to an owned `Vec<Match>` before returning, so a panic in the engine becomes an error rather than a process crash.
* `BTreeMap` for metadata; matches sorted by `(rule_name, namespace, first_offset)` so the same input produces the same `ScanReport` byte for byte across runs.

Tests

126 tests across eight layers:

* 92 unit tests (error / match types / audit / compile / cache / scan / backend modules)
* 6 audit evasion regression tests (whitespace, escapes, comments, split-line imports)
* 1 chaos test (8 worker threads, 250 random operations each: writes, deletes, scans, reloads, with no panics or deadlocks)
* 3 concurrency tests (parallel scans, parallel reloads, mixed read / write from `Arc<YaraBackend>`)
* 5 determinism tests (byte for byte identical reports across runs; sorted match list; alphabetic meta key order)
* 8 inline rule regression tests, one per existing consumer that ships a rule string today
* 9 file rule tests against committed fixtures in `tests/fixtures/rules/`
* 2 README example tests so the snippets in `README.md` always compile and run

Plus three criterion benchmarks (compile, scan_bytes, scan_file) with a captured baseline in `BASELINE.md` for future comparison.

A companion shell script `tools/audit_yara_rules.sh` runs the same unsupported-module check from a CI pre-build hook so bad rules are caught before cargo starts compiling.

What this PR does NOT do

* No caller migration. `fileanalyzer`, `mzhash`, `mzcount`, `xmzhash`, and `mismatchminer` keep using the libyara `yara` crate. Migration is one PR per caller in follow-ups.
* No removal of libyara from the workspace. That happens once every caller has moved.
* No CI changes.

Trust model and platforms

The crate is designed for rule sources MalChela itself ships (inline constants baked into binaries) and rule files an operator drops into `yara_rules/` on a machine they control. Both are trusted inputs at this layer. The hard size caps cover the runaway allocation case.

`YaraBackend` is `Send + Sync` and cheap to clone (backed by an `Arc`). Wrap it in an `Arc` and hand it to worker pools.

License: MIT, matching MalChela. yara-x is BSD-3-Clause and ships as a normal crate dependency.

Cheers,
Daniel